### PR TITLE
Add purchase history Lightning component and Apex controller

### DIFF
--- a/.forceignore
+++ b/.forceignore
@@ -1,0 +1,12 @@
+# List files or directories below to ignore them when running force:source:push, force:source:pull, and force:source:status
+# More information: https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_exclude_source.htm
+#
+
+package.xml
+
+# LWC configuration files
+**/jsconfig.json
+**/.eslintrc.json
+
+# LWC Jest
+**/__tests__/**

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,48 @@
+# This file is used for Git repositories to specify intentionally untracked files that Git should ignore. 
+# If you are not using git, you can delete this file. For more information see: https://git-scm.com/docs/gitignore
+# For useful gitignore templates see: https://github.com/github/gitignore
+
+# Salesforce cache
+.sf/
+.sfdx/
+.localdevserver/
+deploy-options.json
+
+# LWC VSCode autocomplete
+**/lwc/jsconfig.json
+
+# LWC Jest coverage reports
+coverage/
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Dependency directories
+node_modules/
+
+# ApexPMD cache
+.pmdCache
+
+# Eslint cache
+.eslintcache
+
+# MacOS system files
+.DS_Store
+
+# Windows system files
+Thumbs.db
+ehthumbs.db
+[Dd]esktop.ini
+$RECYCLE.BIN/
+
+# Local environment variables
+.env
+
+# Python Salesforce Functions
+**/__pycache__/
+**/.venv/
+**/venv/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npm run precommit

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,11 @@
+# List files or directories below to ignore them when running prettier
+# More information: https://prettier.io/docs/en/ignore.html
+#
+
+**/staticresources/**
+.localdevserver
+.sfdx
+.sf
+.vscode
+
+coverage/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,17 @@
+{
+  "trailingComma": "none",
+  "plugins": [
+    "prettier-plugin-apex",
+    "@prettier/plugin-xml"
+  ],
+  "overrides": [
+    {
+      "files": "**/lwc/**/*.html",
+      "options": { "parser": "lwc" }
+    },
+    {
+      "files": "*.{cmp,page,component}",
+      "options": { "parser": "html" }
+    }
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  "recommendations": [
+    "salesforce.salesforcedx-vscode",
+    "redhat.vscode-xml",
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "financialforce.lana"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch Apex Replay Debugger",
+      "type": "apex-replay",
+      "request": "launch",
+      "logFile": "${command:AskForLogFileName}",
+      "stopOnEntry": true,
+      "trace": true
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/bower_components": true,
+    "**/.sfdx": true
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# novarigel
+# Purchase History LWC Sample
+
+This project contains a Salesforce Lightning Web Component (LWC) and Apex classes that expose a purchase history view for Account records. The component surfaces order line item details, including product data, and can be added to Account record pages, app pages, or the home page.
+
+## Contents
+
+- `force-app/main/default/classes/PurchaseHistoryController.cls`: Apex controller that aggregates purchase history information from related Order and OrderItem records.
+- `force-app/main/default/classes/PurchaseHistoryControllerTest.cls`: Apex unit tests covering the purchase history controller.
+- `force-app/main/default/lwc/purchaseHistory/`: Lightning Web Component that renders the purchase history data in a data table.
+
+## Deployment
+
+Use Salesforce CLI to deploy the metadata to your org:
+
+```bash
+sfdx force:source:deploy -p force-app/main/default
+```
+
+## Usage
+
+1. Deploy the metadata to your Salesforce org.
+2. Add the **Purchase History** component to an Account record page using the Lightning App Builder.
+3. Save and activate the page.
+4. Navigate to an Account record with related Orders and Order Items to see the purchase history.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,18 @@
-# Purchase History LWC Sample
+# Salesforce DX Project: Next Steps
 
-This project contains a Salesforce Lightning Web Component (LWC) and Apex classes that expose a purchase history view for Account records. The component surfaces order line item details, including product data, and can be added to Account record pages, app pages, or the home page.
+Now that you’ve created a Salesforce DX project, what’s next? Here are some documentation resources to get you started.
 
-## Contents
+## How Do You Plan to Deploy Your Changes?
 
-- `force-app/main/default/classes/PurchaseHistoryController.cls`: Apex controller that aggregates purchase history information from related Order and OrderItem records.
-- `force-app/main/default/classes/PurchaseHistoryControllerTest.cls`: Apex unit tests covering the purchase history controller.
-- `force-app/main/default/lwc/purchaseHistory/`: Lightning Web Component that renders the purchase history data in a data table.
+Do you want to deploy a set of changes, or create a self-contained application? Choose a [development model](https://developer.salesforce.com/tools/vscode/en/user-guide/development-models).
 
-## Deployment
+## Configure Your Salesforce DX Project
 
-Use Salesforce CLI to deploy the metadata to your org:
+The `sfdx-project.json` file contains useful configuration information for your project. See [Salesforce DX Project Configuration](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_ws_config.htm) in the _Salesforce DX Developer Guide_ for details about this file.
 
-```bash
-sfdx force:source:deploy -p force-app/main/default
-```
+## Read All About It
 
-## Usage
-
-1. Deploy the metadata to your Salesforce org.
-2. Add the **Purchase History** component to an Account record page using the Lightning App Builder.
-3. Save and activate the page.
-4. Navigate to an Account record with related Orders and Order Items to see the purchase history.
+- [Salesforce Extensions Documentation](https://developer.salesforce.com/tools/vscode/)
+- [Salesforce CLI Setup Guide](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_intro.htm)
+- [Salesforce DX Developer Guide](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_intro.htm)
+- [Salesforce CLI Command Reference](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference.htm)

--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,0 +1,13 @@
+{
+  "orgName": "Demo company",
+  "edition": "Developer",
+  "features": ["EnableSetPasswordInApi"],
+  "settings": {
+    "lightningExperienceSettings": {
+      "enableS1DesktopEnabled": true
+    },
+    "mobileSettings": {
+      "enableS1EncryptedStoragePref2": false
+    }
+  }
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,55 @@
+const { defineConfig } = require('eslint/config');
+const eslintJs = require('@eslint/js');
+const jestPlugin = require('eslint-plugin-jest');
+const auraConfig = require('@salesforce/eslint-plugin-aura');
+const lwcConfig = require('@salesforce/eslint-config-lwc/recommended');
+const globals = require('globals');
+
+module.exports = defineConfig([
+    // Aura configuration
+    {
+        files: ['**/aura/**/*.js'],
+        extends: [
+            ...auraConfig.configs.recommended,
+            ...auraConfig.configs.locker
+        ]
+    },
+
+    // LWC configuration
+    {
+        files: ['**/lwc/**/*.js'],
+        extends: [lwcConfig]
+    },
+
+    // LWC configuration with override for LWC test files
+    {
+        files: ['**/lwc/**/*.test.js'],
+        extends: [lwcConfig],
+        rules: {
+            '@lwc/lwc/no-unexpected-wire-adapter-usages': 'off'
+        },
+        languageOptions: {
+            globals: {
+                ...globals.node
+            }
+        }
+    },
+
+    // Jest mocks configuration
+    {
+        files: ['**/jest-mocks/**/*.js'],
+        languageOptions: {
+            sourceType: 'module',
+            ecmaVersion: 'latest',
+            globals: {
+                ...globals.node,
+                ...globals.es2021,
+                ...jestPlugin.environments.globals.globals
+            }
+        },
+        plugins: {
+            eslintJs
+        },
+        extends: ['eslintJs/recommended']
+    }
+]);

--- a/force-app/main/default/classes/PurchaseHistoryController.cls
+++ b/force-app/main/default/classes/PurchaseHistoryController.cls
@@ -1,0 +1,61 @@
+public with sharing class PurchaseHistoryController {
+    public class PurchaseHistoryItem {
+        @AuraEnabled public Id orderId { get; set; }
+        @AuraEnabled public String orderNumber { get; set; }
+        @AuraEnabled public Date purchaseDate { get; set; }
+        @AuraEnabled public String status { get; set; }
+        @AuraEnabled public Id orderItemId { get; set; }
+        @AuraEnabled public Decimal quantity { get; set; }
+        @AuraEnabled public Decimal unitPrice { get; set; }
+        @AuraEnabled public Decimal totalPrice { get; set; }
+        @AuraEnabled public String productName { get; set; }
+        @AuraEnabled public String productCode { get; set; }
+        @AuraEnabled public String productDescription { get; set; }
+        @AuraEnabled public String currencyIsoCode { get; set; }
+    }
+
+    @AuraEnabled(cacheable=true)
+    public static List<PurchaseHistoryItem> getPurchaseHistory(Id accountId) {
+        if (accountId == null) {
+            throw new AuraHandledException('An account Id is required to view purchase history.');
+        }
+
+        List<OrderItem> orderItems = [
+            SELECT Id,
+                   OrderId,
+                   Order.OrderNumber,
+                   Order.EffectiveDate,
+                   Order.Status,
+                   Order.CurrencyIsoCode,
+                   Quantity,
+                   UnitPrice,
+                   TotalPrice,
+                   Product2.Name,
+                   Product2.ProductCode,
+                   Product2.Description
+            FROM OrderItem
+            WHERE Order.AccountId = :accountId
+            ORDER BY Order.EffectiveDate DESC, Order.OrderNumber DESC
+        ];
+
+        List<PurchaseHistoryItem> results = new List<PurchaseHistoryItem>();
+        for (OrderItem item : orderItems) {
+            PurchaseHistoryItem historyItem = new PurchaseHistoryItem();
+            historyItem.orderId = item.OrderId;
+            historyItem.orderNumber = item.Order.OrderNumber;
+            historyItem.purchaseDate = item.Order.EffectiveDate;
+            historyItem.status = item.Order.Status;
+            historyItem.orderItemId = item.Id;
+            historyItem.quantity = item.Quantity;
+            historyItem.unitPrice = item.UnitPrice;
+            historyItem.totalPrice = item.TotalPrice;
+            historyItem.productName = item.Product2 != null ? item.Product2.Name : null;
+            historyItem.productCode = item.Product2 != null ? item.Product2.ProductCode : null;
+            historyItem.productDescription = item.Product2 != null ? item.Product2.Description : null;
+            historyItem.currencyIsoCode = item.Order.CurrencyIsoCode;
+            results.add(historyItem);
+        }
+
+        return results;
+    }
+}

--- a/force-app/main/default/classes/PurchaseHistoryController.cls-meta.xml
+++ b/force-app/main/default/classes/PurchaseHistoryController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/PurchaseHistoryControllerTest.cls
+++ b/force-app/main/default/classes/PurchaseHistoryControllerTest.cls
@@ -1,0 +1,63 @@
+@IsTest
+private class PurchaseHistoryControllerTest {
+    @IsTest
+    static void testGetPurchaseHistory() {
+        Account account = new Account(Name = 'Test Account');
+        insert account;
+
+        Pricebook2 standardPricebook = [SELECT Id FROM Pricebook2 WHERE IsStandard = true LIMIT 1];
+
+        Product2 product = new Product2(Name = 'Test Product', ProductCode = 'TP-001', isActive = true);
+        insert product;
+
+        PricebookEntry pricebookEntry = new PricebookEntry(
+            Pricebook2Id = standardPricebook.Id,
+            Product2Id = product.Id,
+            UnitPrice = 100,
+            IsActive = true
+        );
+        insert pricebookEntry;
+
+        Order orderRecord = new Order(
+            AccountId = account.Id,
+            EffectiveDate = Date.today(),
+            Status = 'Draft',
+            Pricebook2Id = standardPricebook.Id
+        );
+        insert orderRecord;
+
+        OrderItem orderItem = new OrderItem(
+            OrderId = orderRecord.Id,
+            PricebookEntryId = pricebookEntry.Id,
+            Quantity = 2,
+            UnitPrice = 100
+        );
+        insert orderItem;
+
+        Test.startTest();
+        List<PurchaseHistoryController.PurchaseHistoryItem> history = PurchaseHistoryController.getPurchaseHistory(account.Id);
+        Test.stopTest();
+
+        System.assertEquals(1, history.size(), 'A single order item should be returned.');
+        PurchaseHistoryController.PurchaseHistoryItem item = history[0];
+        System.assertEquals(orderRecord.Id, item.orderId, 'Order Id should match.');
+        System.assertEquals(orderItem.Id, item.orderItemId, 'Order item Id should match.');
+        System.assertEquals(product.Name, item.productName, 'Product name should match.');
+        System.assertEquals(product.ProductCode, item.productCode, 'Product code should match.');
+        System.assertEquals(orderItem.Quantity, item.quantity, 'Quantity should match.');
+        System.assertEquals(orderItem.UnitPrice, item.unitPrice, 'Unit price should match.');
+        System.assertEquals(orderItem.TotalPrice, item.totalPrice, 'Total price should match.');
+    }
+
+    @IsTest
+    static void testGetPurchaseHistoryRequiresAccountId() {
+        Test.startTest();
+        try {
+            PurchaseHistoryController.getPurchaseHistory(null);
+            System.assert(false, 'Method should throw an error when account Id is not provided.');
+        } catch (AuraHandledException e) {
+            System.assertEquals('An account Id is required to view purchase history.', e.getMessage());
+        }
+        Test.stopTest();
+    }
+}

--- a/force-app/main/default/classes/PurchaseHistoryControllerTest.cls-meta.xml
+++ b/force-app/main/default/classes/PurchaseHistoryControllerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/purchaseHistory/purchaseHistory.css
+++ b/force-app/main/default/lwc/purchaseHistory/purchaseHistory.css
@@ -1,0 +1,4 @@
+.empty-message {
+    color: var(--lwc-colorTextWeak, #706e6b);
+    margin: var(--lwc-spacingMedium, 1rem) 0;
+}

--- a/force-app/main/default/lwc/purchaseHistory/purchaseHistory.html
+++ b/force-app/main/default/lwc/purchaseHistory/purchaseHistory.html
@@ -1,0 +1,29 @@
+<template>
+    <lightning-card title="Purchase History" icon-name="custom:custom63">
+        <div class="slds-p-horizontal_medium">
+            <template if:true={isLoading}>
+                <lightning-spinner alternative-text="Loading purchase history" size="medium"></lightning-spinner>
+            </template>
+            <template if:true={error}>
+                <div class="slds-notify slds-notify_alert slds-theme_alert-texture slds-theme_error" role="alert">
+                    <span class="slds-assistive-text">Error</span>
+                    <h2>{errorMessage}</h2>
+                </div>
+            </template>
+            <template if:true={hasData}>
+                <lightning-datatable key-field="orderItemId"
+                                     data={purchaseHistory}
+                                     columns={columns}
+                                     hide-checkbox-column>
+                </lightning-datatable>
+            </template>
+            <template if:false={hasData}>
+                <template if:false={isLoading}>
+                    <p class="slds-text-body_regular slds-text-align_center empty-message">
+                        No purchase history was found for this account.
+                    </p>
+                </template>
+            </template>
+        </div>
+    </lightning-card>
+</template>

--- a/force-app/main/default/lwc/purchaseHistory/purchaseHistory.js
+++ b/force-app/main/default/lwc/purchaseHistory/purchaseHistory.js
@@ -1,0 +1,66 @@
+import { LightningElement, api, track } from 'lwc';
+import getPurchaseHistory from '@salesforce/apex/PurchaseHistoryController.getPurchaseHistory';
+import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+
+const columns = [
+    { label: 'Order Number', fieldName: 'orderNumber', type: 'text', sortable: true },
+    { label: 'Purchase Date', fieldName: 'purchaseDate', type: 'date-local', sortable: true },
+    { label: 'Status', fieldName: 'status', type: 'text' },
+    { label: 'Product Name', fieldName: 'productName', type: 'text' },
+    { label: 'Product Code', fieldName: 'productCode', type: 'text' },
+    { label: 'Quantity', fieldName: 'quantity', type: 'number' },
+    { label: 'Unit Price', fieldName: 'unitPrice', type: 'currency', typeAttributes: { currencyCode: { fieldName: 'currencyIsoCode' } } },
+    { label: 'Total Price', fieldName: 'totalPrice', type: 'currency', typeAttributes: { currencyCode: { fieldName: 'currencyIsoCode' } } }
+];
+
+export default class PurchaseHistory extends LightningElement {
+    @api recordId;
+    @track purchaseHistory = [];
+    @track error;
+    isLoading = false;
+
+    columns = columns;
+
+    connectedCallback() {
+        this.loadPurchaseHistory();
+    }
+
+    get hasData() {
+        return this.purchaseHistory && this.purchaseHistory.length > 0;
+    }
+
+    get errorMessage() {
+        return this.error?.body?.message || this.error?.message || 'An unexpected error occurred.';
+    }
+
+    async loadPurchaseHistory() {
+        if (!this.recordId) {
+            this.error = { message: 'The component requires an Account record Id to display purchase history.' };
+            return;
+        }
+
+        this.isLoading = true;
+        this.error = undefined;
+
+        try {
+            const history = await getPurchaseHistory({ accountId: this.recordId });
+            this.purchaseHistory = history?.map((item) => ({
+                ...item,
+                purchaseDate: item.purchaseDate,
+                unitPrice: item.unitPrice,
+                totalPrice: item.totalPrice
+            })) || [];
+        } catch (error) {
+            this.error = error;
+            this.dispatchEvent(
+                new ShowToastEvent({
+                    title: 'Error loading purchase history',
+                    message: this.errorMessage,
+                    variant: 'error'
+                })
+            );
+        } finally {
+            this.isLoading = false;
+        }
+    }
+}

--- a/force-app/main/default/lwc/purchaseHistory/purchaseHistory.js-meta.xml
+++ b/force-app/main/default/lwc/purchaseHistory/purchaseHistory.js-meta.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__RecordPage</target>
+        <target>lightning__AppPage</target>
+        <target>lightning__HomePage</target>
+    </targets>
+    <targetConfigs>
+        <targetConfig targets="lightning__RecordPage">
+            <objects>
+                <object>Account</object>
+            </objects>
+        </targetConfig>
+    </targetConfigs>
+</LightningComponentBundle>

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+const { jestConfig } = require('@salesforce/sfdx-lwc-jest/config');
+
+module.exports = {
+    ...jestConfig,
+    modulePathIgnorePatterns: ['<rootDir>/.localdevserver']
+};

--- a/manifest/package.xml
+++ b/manifest/package.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>*</members>
+        <name>ApexClass</name>
+    </types>
+    <types>
+        <members>*</members>
+        <name>ApexComponent</name>
+    </types>
+    <types>
+        <members>*</members>
+        <name>ApexPage</name>
+    </types>
+    <types>
+        <members>*</members>
+        <name>ApexTestSuite</name>
+    </types>
+    <types>
+        <members>*</members>
+        <name>ApexTrigger</name>
+    </types>
+    <types>
+        <members>*</members>
+        <name>AuraDefinitionBundle</name>
+    </types>
+    <types>
+        <members>*</members>
+        <name>LightningComponentBundle</name>
+    </types>
+    <types>
+        <members>*</members>
+        <name>StaticResource</name>
+    </types>
+    <version>64.0</version>
+</Package>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "salesforce-app",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Salesforce App",
+  "scripts": {
+    "lint": "eslint **/{aura,lwc}/**/*.js",
+    "test": "npm run test:unit",
+    "test:unit": "sfdx-lwc-jest",
+    "test:unit:watch": "sfdx-lwc-jest --watch",
+    "test:unit:debug": "sfdx-lwc-jest --debug",
+    "test:unit:coverage": "sfdx-lwc-jest --coverage",
+    "prettier": "prettier --write \"**/*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}\"",
+    "prettier:verify": "prettier --check \"**/*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}\"",
+    "prepare": "husky || true",
+    "precommit": "lint-staged"
+  },
+  "devDependencies": {
+    "@lwc/eslint-plugin-lwc": "^3.1.0",
+    "@prettier/plugin-xml": "^3.4.1",
+    "@salesforce/eslint-config-lwc": "^4.0.0",
+    "@salesforce/eslint-plugin-aura": "^3.0.0",
+    "@salesforce/eslint-plugin-lightning": "^2.0.0",
+    "@salesforce/sfdx-lwc-jest": "^7.0.2",
+    "eslint": "^9.29.0",
+    "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-jest": "^28.14.0",
+    "husky": "^9.1.7",
+    "lint-staged": "^16.1.2",
+    "prettier": "^3.5.3",
+    "prettier-plugin-apex": "^2.2.6"
+  },
+  "lint-staged": {
+    "**/*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}": [
+      "prettier --write"
+    ],
+    "**/{aura,lwc}/**/*.js": [
+      "eslint"
+    ],
+    "**/lwc/**": [
+        "sfdx-lwc-jest -- --bail --findRelatedTests --passWithNoTests"
+    ]
+  }
+}

--- a/scripts/apex/hello.apex
+++ b/scripts/apex/hello.apex
@@ -1,0 +1,10 @@
+// Use .apex files to store anonymous Apex.
+// You can execute anonymous Apex in VS Code by selecting the
+//     apex text and running the command:
+//     SFDX: Execute Anonymous Apex with Currently Selected Text
+// You can also execute the entire file by running the command:
+//     SFDX: Execute Anonymous Apex with Editor Contents
+
+string tempvar = 'Enter_your_name_here';
+System.debug('Hello World!');
+System.debug('My name is ' + tempvar);

--- a/scripts/soql/account.soql
+++ b/scripts/soql/account.soql
@@ -1,0 +1,6 @@
+// Use .soql files to store SOQL queries.
+// You can execute queries in VS Code by selecting the
+//     query text and running the command:
+//     SFDX: Execute SOQL Query with Currently Selected Text
+
+SELECT Id, Name FROM Account

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,0 +1,12 @@
+{
+  "packageDirectories": [
+    {
+      "path": "force-app",
+      "default": true
+    }
+  ],
+  "name": "novarigel",
+  "namespace": "",
+  "sfdcLoginUrl": "https://login.salesforce.com",
+  "sourceApiVersion": "64.0"
+}


### PR DESCRIPTION
## Summary
- add an Apex controller that surfaces purchase history details for an Account, including product information
- create unit tests covering the controller logic and error handling
- build a Purchase History Lightning Web Component that renders the data in a datatable and handle loading/error states

## Testing
- not run (Salesforce-specific tests require an org)

------
https://chatgpt.com/codex/tasks/task_e_68dbcfb2fd70832c80bb30c2563a56bc