### PR TITLE
Expose purchase history LWC to Experience Cloud

### DIFF
--- a/force-app/main/default/lwc/purchaseHistory/purchaseHistory.js-meta.xml
+++ b/force-app/main/default/lwc/purchaseHistory/purchaseHistory.js-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__AppPage</target>
+        <target>lightning__HomePage</target>
+        <target>lightning__RecordPage</target>
+        <target>lightningCommunity__Page</target>
+        <target>lightningCommunity__Default</target>
+    </targets>
+</LightningComponentBundle>


### PR DESCRIPTION
## Summary
- add Experience Cloud targets to the purchaseHistory LWC metadata so it can be used on community pages

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dbdc64fa5c832cb7c0e3b4e133337d