### PR TITLE
feat: display purchase history cards in Japanese

### DIFF
--- a/force-app/main/default/lwc/purchaseHistory/purchaseHistory.css
+++ b/force-app/main/default/lwc/purchaseHistory/purchaseHistory.css
@@ -1,3 +1,51 @@
+.history-card {
+    display: flex;
+}
+
+.history-card .slds-card__body {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    gap: var(--lwc-spacingSmall, 0.75rem);
+}
+
+.card-header {
+    border-bottom: 1px solid var(--lwc-colorBorder, #dddbda);
+    padding-bottom: var(--lwc-spacingXSmall, 0.5rem);
+}
+
+.card-header__title {
+    font-weight: var(--lwc-fontWeightBold, 700);
+    margin: 0;
+}
+
+.card-header__subtitle {
+    color: var(--lwc-colorTextWeak, #706e6b);
+    margin: 0;
+}
+
+.detail-list {
+    display: grid;
+    gap: var(--lwc-spacingSmall, 0.75rem);
+}
+
+.detail-row {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--lwc-spacingSmall, 0.75rem);
+}
+
+.detail-row dt {
+    font-weight: var(--lwc-fontWeightBold, 700);
+    margin: 0;
+}
+
+.detail-row dd {
+    margin: 0;
+    text-align: right;
+    flex: 1;
+}
+
 .empty-message {
     color: var(--lwc-colorTextWeak, #706e6b);
     margin: var(--lwc-spacingMedium, 1rem) 0;

--- a/force-app/main/default/lwc/purchaseHistory/purchaseHistory.html
+++ b/force-app/main/default/lwc/purchaseHistory/purchaseHistory.html
@@ -1,26 +1,60 @@
 <template>
-    <lightning-card title="Purchase History" icon-name="custom:custom63">
+    <lightning-card title="購入履歴" icon-name="custom:custom63">
         <div class="slds-p-horizontal_medium">
             <template if:true={isLoading}>
-                <lightning-spinner alternative-text="Loading purchase history" size="medium"></lightning-spinner>
+                <lightning-spinner alternative-text="購入履歴を読み込み中" size="medium"></lightning-spinner>
             </template>
             <template if:true={error}>
                 <div class="slds-notify slds-notify_alert slds-theme_alert-texture slds-theme_error" role="alert">
-                    <span class="slds-assistive-text">Error</span>
+                    <span class="slds-assistive-text">エラー</span>
                     <h2>{errorMessage}</h2>
                 </div>
             </template>
             <template if:true={hasData}>
-                <lightning-datatable key-field="orderItemId"
-                                     data={purchaseHistory}
-                                     columns={columns}
-                                     hide-checkbox-column>
-                </lightning-datatable>
+                <div class="history-grid slds-grid slds-wrap slds-gutters">
+                    <template for:each={purchaseHistory} for:item="item">
+                        <article key={item.orderItemId}
+                                 class="history-card slds-card slds-col slds-size_1-of-1 slds-medium-size_1-of-2 slds-large-size_1-of-3">
+                            <div class="slds-card__body slds-card__body_inner">
+                                <header class="card-header">
+                                    <p class="card-header__title">注文番号: {item.orderNumber}</p>
+                                    <p class="card-header__subtitle">購入日: {item.purchaseDateFormatted}</p>
+                                </header>
+                                <dl class="detail-list">
+                                    <div class="detail-row">
+                                        <dt>状態</dt>
+                                        <dd>{item.status}</dd>
+                                    </div>
+                                    <div class="detail-row">
+                                        <dt>商品名</dt>
+                                        <dd>{item.productName}</dd>
+                                    </div>
+                                    <div class="detail-row">
+                                        <dt>商品コード</dt>
+                                        <dd>{item.productCode}</dd>
+                                    </div>
+                                    <div class="detail-row">
+                                        <dt>数量</dt>
+                                        <dd>{item.quantityFormatted}</dd>
+                                    </div>
+                                    <div class="detail-row">
+                                        <dt>単価</dt>
+                                        <dd>{item.unitPriceFormatted}</dd>
+                                    </div>
+                                    <div class="detail-row">
+                                        <dt>合計金額</dt>
+                                        <dd>{item.totalPriceFormatted}</dd>
+                                    </div>
+                                </dl>
+                            </div>
+                        </article>
+                    </template>
+                </div>
             </template>
             <template if:false={hasData}>
                 <template if:false={isLoading}>
                     <p class="slds-text-body_regular slds-text-align_center empty-message">
-                        No purchase history was found for this account.
+                        この取引先の購入履歴は見つかりませんでした。
                     </p>
                 </template>
             </template>

--- a/force-app/main/default/lwc/purchaseHistory/purchaseHistory.js
+++ b/force-app/main/default/lwc/purchaseHistory/purchaseHistory.js
@@ -2,24 +2,11 @@ import { LightningElement, api, track } from 'lwc';
 import getPurchaseHistory from '@salesforce/apex/PurchaseHistoryController.getPurchaseHistory';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 
-const columns = [
-    { label: 'Order Number', fieldName: 'orderNumber', type: 'text', sortable: true },
-    { label: 'Purchase Date', fieldName: 'purchaseDate', type: 'date-local', sortable: true },
-    { label: 'Status', fieldName: 'status', type: 'text' },
-    { label: 'Product Name', fieldName: 'productName', type: 'text' },
-    { label: 'Product Code', fieldName: 'productCode', type: 'text' },
-    { label: 'Quantity', fieldName: 'quantity', type: 'number' },
-    { label: 'Unit Price', fieldName: 'unitPrice', type: 'currency', typeAttributes: { currencyCode: { fieldName: 'currencyIsoCode' } } },
-    { label: 'Total Price', fieldName: 'totalPrice', type: 'currency', typeAttributes: { currencyCode: { fieldName: 'currencyIsoCode' } } }
-];
-
 export default class PurchaseHistory extends LightningElement {
     @api recordId;
     @track purchaseHistory = [];
     @track error;
     isLoading = false;
-
-    columns = columns;
 
     connectedCallback() {
         this.loadPurchaseHistory();
@@ -30,12 +17,18 @@ export default class PurchaseHistory extends LightningElement {
     }
 
     get errorMessage() {
-        return this.error?.body?.message || this.error?.message || 'An unexpected error occurred.';
+        return (
+            this.error?.body?.message ||
+            this.error?.message ||
+            '予期せぬエラーが発生しました。'
+        );
     }
 
     async loadPurchaseHistory() {
         if (!this.recordId) {
-            this.error = { message: 'The component requires an Account record Id to display purchase history.' };
+            this.error = {
+                message: '購入履歴を表示するには取引先のレコードIDが必要です。'
+            };
             return;
         }
 
@@ -44,17 +37,13 @@ export default class PurchaseHistory extends LightningElement {
 
         try {
             const history = await getPurchaseHistory({ accountId: this.recordId });
-            this.purchaseHistory = history?.map((item) => ({
-                ...item,
-                purchaseDate: item.purchaseDate,
-                unitPrice: item.unitPrice,
-                totalPrice: item.totalPrice
-            })) || [];
+            this.purchaseHistory =
+                history?.map((item) => this.formatHistoryItem(item)) || [];
         } catch (error) {
             this.error = error;
             this.dispatchEvent(
                 new ShowToastEvent({
-                    title: 'Error loading purchase history',
+                    title: '購入履歴の読み込みエラー',
                     message: this.errorMessage,
                     variant: 'error'
                 })
@@ -62,5 +51,33 @@ export default class PurchaseHistory extends LightningElement {
         } finally {
             this.isLoading = false;
         }
+    }
+
+    formatHistoryItem(item) {
+        const dateFormatter = new Intl.DateTimeFormat('ja-JP');
+        const currencyFormatter = new Intl.NumberFormat('ja-JP', {
+            style: 'currency',
+            currency: item.currencyIsoCode || 'JPY'
+        });
+        const numberFormatter = new Intl.NumberFormat('ja-JP');
+
+        return {
+            ...item,
+            purchaseDateFormatted: item.purchaseDate
+                ? dateFormatter.format(new Date(item.purchaseDate))
+                : '',
+            quantityFormatted:
+                item.quantity !== undefined && item.quantity !== null
+                    ? numberFormatter.format(item.quantity)
+                    : '',
+            unitPriceFormatted:
+                item.unitPrice !== undefined && item.unitPrice !== null
+                    ? currencyFormatter.format(item.unitPrice)
+                    : '',
+            totalPriceFormatted:
+                item.totalPrice !== undefined && item.totalPrice !== null
+                    ? currencyFormatter.format(item.totalPrice)
+                    : ''
+        };
     }
 }


### PR DESCRIPTION
## Summary
- replace the purchase history data table with a three-column card layout that better surfaces order details
- localize labels, messages, and toast notifications to Japanese and format values for Japanese users
- add styling for the new card grid presentation

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd12637358832cbdf8fe1a815fb211