### PR TITLE
feat: deliver Amazon-style purchase history layout

### DIFF
--- a/force-app/main/default/lwc/purchaseHistory/purchaseHistory.css
+++ b/force-app/main/default/lwc/purchaseHistory/purchaseHistory.css
@@ -1,4 +1,268 @@
+:host {
+    display: block;
+}
+
+.purchase-history {
+    background-color: #f6f7f8;
+    padding: var(--lwc-spacingLarge, 1.5rem) var(--lwc-spacingMedium, 1rem);
+}
+
+.state {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: var(--lwc-spacingXLarge, 2rem) 0;
+}
+
+.state--error {
+    flex-direction: column;
+    gap: var(--lwc-spacingSmall, 0.75rem);
+    text-align: center;
+}
+
+.order-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--lwc-spacingXLarge, 2rem);
+}
+
+.order-card {
+    background-color: #ffffff;
+    border: 1px solid #d5d9d9;
+    border-radius: 12px;
+    box-shadow: 0 6px 14px rgba(15, 17, 17, 0.12);
+    overflow: hidden;
+}
+
+.order-card__header {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--lwc-spacingLarge, 1.5rem);
+    padding: var(--lwc-spacingLarge, 1.5rem);
+    background-color: #f7fafa;
+    border-bottom: 1px solid #e7e7e7;
+}
+
+.order-card__summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: var(--lwc-spacingSmall, 0.75rem);
+    color: #0f1111;
+}
+
+.order-card__summary p {
+    margin: 0;
+    font-size: 0.95rem;
+}
+
+.order-card__date,
+.order-card__number,
+.order-card__status {
+    color: #565959;
+}
+
+.order-card__total {
+    font-weight: 600;
+    color: #b12704;
+}
+
+.order-card__actions {
+    display: flex;
+    flex-direction: column;
+    gap: var(--lwc-spacingXSmall, 0.5rem);
+    min-width: 200px;
+    align-items: flex-start;
+}
+
+.order-action {
+    width: 100%;
+    border-radius: 999px;
+    border: 1px solid #d5d9d9;
+    background: linear-gradient(180deg, #f7f8fa 0%, #e7e9ec 100%);
+    color: #0f1111;
+    font-size: 0.9rem;
+    font-weight: 600;
+    padding: 0.55rem 1.25rem;
+    cursor: pointer;
+    transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.order-action:hover,
+.order-action:focus {
+    box-shadow: 0 2px 6px rgba(15, 17, 17, 0.2);
+    transform: translateY(-1px);
+}
+
+.order-action--primary {
+    background: linear-gradient(180deg, #ffd814 0%, #f2c200 100%);
+    border-color: #f0c14b;
+}
+
+.order-items {
+    list-style: none;
+    margin: 0;
+    padding: var(--lwc-spacingLarge, 1.5rem);
+    display: flex;
+    flex-direction: column;
+    gap: var(--lwc-spacingLarge, 1.5rem);
+}
+
+.order-item {
+    display: flex;
+    gap: var(--lwc-spacingLarge, 1.5rem);
+}
+
+.order-item__thumb {
+    width: 96px;
+    height: 96px;
+    border-radius: 8px;
+    background-color: #f0f2f2;
+    border: 1px solid #d5d9d9;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: #565959;
+}
+
+.order-item__details {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: var(--lwc-spacingSmall, 0.75rem);
+}
+
+.order-item__title {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #0f1111;
+}
+
+.order-item__code {
+    margin: 0;
+    font-size: 0.85rem;
+    color: #565959;
+}
+
+.order-item__description {
+    margin: 0;
+    font-size: 0.95rem;
+    color: #0f1111;
+    line-height: 1.5;
+}
+
+.order-item__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--lwc-spacingSmall, 0.75rem);
+    font-size: 0.9rem;
+    color: #565959;
+}
+
+.order-item__meta-item {
+    background-color: #f0f2f2;
+    border-radius: 999px;
+    padding: 0.35rem 0.9rem;
+}
+
+.order-item__meta-item--highlight {
+    background-color: #fff6eb;
+    color: #b12704;
+}
+
+.order-item__buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--lwc-spacingSmall, 0.75rem);
+}
+
+.item-action {
+    border-radius: 999px;
+    border: 1px solid #d5d9d9;
+    background-color: #ffffff;
+    color: #0f1111;
+    font-size: 0.85rem;
+    font-weight: 600;
+    padding: 0.45rem 1.25rem;
+    cursor: pointer;
+    transition: background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.item-action:hover,
+.item-action:focus {
+    background-color: #f7fafa;
+    box-shadow: 0 2px 4px rgba(15, 17, 17, 0.15);
+}
+
+.order-card__footer {
+    border-top: 1px solid #e7e7e7;
+    padding: var(--lwc-spacingMedium, 1rem) var(--lwc-spacingLarge, 1.5rem);
+    background-color: #f7fafa;
+}
+
+.order-card__count {
+    margin: 0;
+    font-size: 0.9rem;
+    color: #565959;
+}
+
 .empty-message {
-    color: var(--lwc-colorTextWeak, #706e6b);
-    margin: var(--lwc-spacingMedium, 1rem) 0;
+    text-align: center;
+    color: #565959;
+    margin: var(--lwc-spacingXLarge, 2rem) 0;
+}
+
+@media (max-width: 900px) {
+    .order-card__header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .order-card__actions {
+        width: 100%;
+        flex-direction: row;
+        flex-wrap: wrap;
+        justify-content: flex-start;
+    }
+
+    .order-action {
+        flex: 1 1 160px;
+    }
+
+    .order-item {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .order-item__thumb {
+        width: 72px;
+        height: 72px;
+        font-size: 1.4rem;
+    }
+}
+
+@media (max-width: 600px) {
+    .purchase-history {
+        padding: var(--lwc-spacingLarge, 1.5rem) var(--lwc-spacingSmall, 0.75rem);
+    }
+
+    .order-card__summary {
+        grid-template-columns: 1fr;
+    }
+
+    .order-item__meta {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .order-item__buttons {
+        width: 100%;
+    }
+
+    .item-action {
+        flex: 1 1 auto;
+        text-align: center;
+    }
 }

--- a/force-app/main/default/lwc/purchaseHistory/purchaseHistory.html
+++ b/force-app/main/default/lwc/purchaseHistory/purchaseHistory.html
@@ -1,27 +1,80 @@
 <template>
-    <lightning-card title="Purchase History" icon-name="custom:custom63">
-        <div class="slds-p-horizontal_medium">
+    <lightning-card title="購入履歴" icon-name="custom:custom63">
+        <div class="purchase-history">
             <template if:true={isLoading}>
-                <lightning-spinner alternative-text="Loading purchase history" size="medium"></lightning-spinner>
+                <div class="state state--loading">
+                    <lightning-spinner alternative-text="購入履歴を読み込み中" size="medium"></lightning-spinner>
+                </div>
             </template>
+
             <template if:true={error}>
-                <div class="slds-notify slds-notify_alert slds-theme_alert-texture slds-theme_error" role="alert">
-                    <span class="slds-assistive-text">Error</span>
+                <div class="state state--error slds-notify slds-notify_alert slds-theme_alert-texture slds-theme_error" role="alert">
+                    <span class="slds-assistive-text">エラー</span>
                     <h2>{errorMessage}</h2>
                 </div>
             </template>
+
             <template if:true={hasData}>
-                <lightning-datatable key-field="orderItemId"
-                                     data={purchaseHistory}
-                                     columns={columns}
-                                     hide-checkbox-column>
-                </lightning-datatable>
+                <div class="order-list">
+                    <template for:each={orders} for:item="order">
+                        <article key={order.orderId} class="order-card">
+                            <header class="order-card__header">
+                                <div class="order-card__summary">
+                                    <p class="order-card__date">注文日: {order.purchaseDateFormatted}</p>
+                                    <p class="order-card__total">合計: {order.totalPriceFormatted}</p>
+                                    <p class="order-card__number">注文番号: {order.orderNumber}</p>
+                                    <p class="order-card__status">配送状況: {order.statusText}</p>
+                                </div>
+                                <div class="order-card__actions">
+                                    <button class="order-action order-action--primary" type="button">配送状況を確認</button>
+                                    <button class="order-action" type="button">商品を再度購入</button>
+                                    <button class="order-action" type="button">注文内容を表示</button>
+                                </div>
+                            </header>
+
+                            <ul class="order-items">
+                                <template for:each={order.items} for:item="orderItem">
+                                    <li key={orderItem.orderItemId} class="order-item">
+                                        <div class="order-item__thumb">
+                                            <span class="order-item__initial">{orderItem.initial}</span>
+                                        </div>
+                                        <div class="order-item__details">
+                                            <h3 class="order-item__title">{orderItem.productName}</h3>
+                                            <template if:true={orderItem.productCode}>
+                                                <p class="order-item__code">商品コード: {orderItem.productCode}</p>
+                                            </template>
+                                            <p class="order-item__description">{orderItem.productDescription}</p>
+                                            <div class="order-item__meta">
+                                                <template if:true={orderItem.quantityFormatted}>
+                                                    <span class="order-item__meta-item">数量: {orderItem.quantityFormatted}</span>
+                                                </template>
+                                                <template if:true={orderItem.unitPriceFormatted}>
+                                                    <span class="order-item__meta-item">単価: {orderItem.unitPriceFormatted}</span>
+                                                </template>
+                                                <template if:true={orderItem.totalPriceFormatted}>
+                                                    <span class="order-item__meta-item order-item__meta-item--highlight">小計: {orderItem.totalPriceFormatted}</span>
+                                                </template>
+                                            </div>
+                                            <div class="order-item__buttons">
+                                                <button class="item-action" type="button">商品を評価</button>
+                                                <button class="item-action" type="button">返品・交換</button>
+                                            </div>
+                                        </div>
+                                    </li>
+                                </template>
+                            </ul>
+
+                            <footer class="order-card__footer">
+                                <p class="order-card__count">{order.itemCountText}</p>
+                            </footer>
+                        </article>
+                    </template>
+                </div>
             </template>
+
             <template if:false={hasData}>
                 <template if:false={isLoading}>
-                    <p class="slds-text-body_regular slds-text-align_center empty-message">
-                        No purchase history was found for this account.
-                    </p>
+                    <p class="empty-message">この取引先の購入履歴は見つかりませんでした。</p>
                 </template>
             </template>
         </div>

--- a/force-app/main/default/lwc/purchaseHistory/purchaseHistory.js
+++ b/force-app/main/default/lwc/purchaseHistory/purchaseHistory.js
@@ -1,60 +1,49 @@
-import { LightningElement, api, track } from 'lwc';
+import { LightningElement, api } from 'lwc';
 import getPurchaseHistory from '@salesforce/apex/PurchaseHistoryController.getPurchaseHistory';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 
-const columns = [
-    { label: 'Order Number', fieldName: 'orderNumber', type: 'text', sortable: true },
-    { label: 'Purchase Date', fieldName: 'purchaseDate', type: 'date-local', sortable: true },
-    { label: 'Status', fieldName: 'status', type: 'text' },
-    { label: 'Product Name', fieldName: 'productName', type: 'text' },
-    { label: 'Product Code', fieldName: 'productCode', type: 'text' },
-    { label: 'Quantity', fieldName: 'quantity', type: 'number' },
-    { label: 'Unit Price', fieldName: 'unitPrice', type: 'currency', typeAttributes: { currencyCode: { fieldName: 'currencyIsoCode' } } },
-    { label: 'Total Price', fieldName: 'totalPrice', type: 'currency', typeAttributes: { currencyCode: { fieldName: 'currencyIsoCode' } } }
-];
-
 export default class PurchaseHistory extends LightningElement {
     @api recordId;
-    @track purchaseHistory = [];
-    @track error;
+    orders = [];
+    error;
     isLoading = false;
-
-    columns = columns;
 
     connectedCallback() {
         this.loadPurchaseHistory();
     }
 
     get hasData() {
-        return this.purchaseHistory && this.purchaseHistory.length > 0;
+        return this.orders && this.orders.length > 0;
     }
 
     get errorMessage() {
-        return this.error?.body?.message || this.error?.message || 'An unexpected error occurred.';
+        return (
+            this.error?.body?.message ||
+            this.error?.message ||
+            '予期せぬエラーが発生しました。'
+        );
     }
 
     async loadPurchaseHistory() {
         if (!this.recordId) {
-            this.error = { message: 'The component requires an Account record Id to display purchase history.' };
+            this.error = {
+                message: '購入履歴を表示するには取引先のレコードIDが必要です。'
+            };
             return;
         }
 
         this.isLoading = true;
         this.error = undefined;
+        this.orders = [];
 
         try {
             const history = await getPurchaseHistory({ accountId: this.recordId });
-            this.purchaseHistory = history?.map((item) => ({
-                ...item,
-                purchaseDate: item.purchaseDate,
-                unitPrice: item.unitPrice,
-                totalPrice: item.totalPrice
-            })) || [];
+            this.orders = this.groupHistoryByOrder(history || []);
         } catch (error) {
             this.error = error;
             this.dispatchEvent(
                 new ShowToastEvent({
-                    title: 'Error loading purchase history',
+                    title: '購入履歴の読み込みエラー',
                     message: this.errorMessage,
                     variant: 'error'
                 })
@@ -62,5 +51,160 @@ export default class PurchaseHistory extends LightningElement {
         } finally {
             this.isLoading = false;
         }
+    }
+
+    groupHistoryByOrder(historyItems) {
+        if (!Array.isArray(historyItems) || historyItems.length === 0) {
+            return [];
+        }
+
+        const ordersById = new Map();
+
+        historyItems.forEach((item) => {
+            const orderId = item.orderId;
+            if (!orderId) {
+                return;
+            }
+
+            if (!ordersById.has(orderId)) {
+                ordersById.set(orderId, {
+                    orderId,
+                    orderNumber: item.orderNumber,
+                    purchaseDate: item.purchaseDate,
+                    status: item.status,
+                    currencyIsoCode: item.currencyIsoCode || 'JPY',
+                    totalPrice: 0,
+                    items: [],
+                    itemCount: 0
+                });
+            }
+
+            const order = ordersById.get(orderId);
+            const hasQuantity =
+                item.quantity !== null && item.quantity !== undefined;
+            const quantity = hasQuantity
+                ? this.getNumericValue(item.quantity)
+                : null;
+            const unitPrice = this.getNumericValue(item.unitPrice);
+            const totalPrice = this.getNumericValue(item.totalPrice);
+
+            order.items.push({
+                orderItemId: item.orderItemId,
+                productName: item.productName || '商品名未設定',
+                productCode: item.productCode,
+                productDescription:
+                    this.formatDescription(item.productDescription),
+                quantityFormatted: hasQuantity
+                    ? this.formatNumber(quantity)
+                    : '',
+                unitPriceFormatted: this.formatCurrency(
+                    unitPrice,
+                    order.currencyIsoCode
+                ),
+                totalPriceFormatted: this.formatCurrency(
+                    totalPrice,
+                    order.currencyIsoCode
+                ),
+                initial: this.getInitial(item.productName)
+            });
+
+            order.totalPrice += totalPrice;
+            const quantityForCount =
+                hasQuantity && quantity > 0 ? quantity : 1;
+            order.itemCount += quantityForCount;
+        });
+
+        return Array.from(ordersById.values()).map((order) => ({
+            ...order,
+            purchaseDateFormatted: this.formatDate(order.purchaseDate),
+            totalPriceFormatted: this.formatCurrency(
+                order.totalPrice,
+                order.currencyIsoCode
+            ),
+            statusText: order.status || '不明',
+            itemCountText: this.formatItemCount(order.itemCount)
+        }));
+    }
+
+    formatDate(value) {
+        if (!value) {
+            return '';
+        }
+
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) {
+            return '';
+        }
+
+        return new Intl.DateTimeFormat('ja-JP', {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric'
+        }).format(date);
+    }
+
+    formatCurrency(value, currencyIsoCode = 'JPY') {
+        if (value === null || value === undefined || Number.isNaN(value)) {
+            return '';
+        }
+
+        return new Intl.NumberFormat('ja-JP', {
+            style: 'currency',
+            currency: currencyIsoCode
+        }).format(value);
+    }
+
+    formatNumber(value) {
+        if (value === null || value === undefined || Number.isNaN(value)) {
+            return '';
+        }
+
+        return new Intl.NumberFormat('ja-JP').format(value);
+    }
+
+    formatDescription(description) {
+        if (!description) {
+            return 'この商品の詳細情報は登録されていません。';
+        }
+
+        const trimmed = description.trim();
+        if (!trimmed) {
+            return 'この商品の詳細情報は登録されていません。';
+        }
+
+        return trimmed.length > 120
+            ? `${trimmed.substring(0, 120)}…`
+            : trimmed;
+    }
+
+    getInitial(name) {
+        if (!name) {
+            return '商';
+        }
+
+        const trimmed = name.trim();
+        return trimmed ? trimmed.charAt(0) : '商';
+    }
+
+    getNumericValue(value) {
+        if (value === null || value === undefined) {
+            return 0;
+        }
+
+        const number = Number(value);
+        return Number.isNaN(number) ? 0 : number;
+    }
+
+    formatItemCount(count) {
+        const value = this.getNumericValue(count);
+        if (value <= 0) {
+            return '商品は含まれていません';
+        }
+
+        if (value === 1) {
+            return '商品数: 1点';
+        }
+
+        return `商品数: ${this.formatNumber(value)}点`;
     }
 }


### PR DESCRIPTION
## Summary
- redesign the purchase history experience into Amazon-inspired order cards with grouped items, inline actions, and Japanese messaging
- group Salesforce注文アイテム by注文 to surface totals, item counts, formatted pricing, and graceful fallbacks for missing product data
- refresh the LWC styling with Amazon-like card treatments, responsive action rows, and centered loading/error states

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd12637358832cbdf8fe1a815fb211