### PR TITLE
Add returns agent integration to purchase history

### DIFF
--- a/force-app/main/default/classes/NovaRigelReturnsAgentController.cls
+++ b/force-app/main/default/classes/NovaRigelReturnsAgentController.cls
@@ -1,0 +1,56 @@
+public with sharing class NovaRigelReturnsAgentController {
+    public class ReturnsAgentSession {
+        @AuraEnabled
+        public String sessionId;
+
+        @AuraEnabled
+        public String launchUrl;
+
+        @AuraEnabled
+        public String conversationId;
+
+        @AuraEnabled
+        public String message;
+    }
+
+    @AuraEnabled
+    public static ReturnsAgentSession launchReturnsAgent(Id orderId, Id orderItemId) {
+        if (orderId == null && orderItemId == null) {
+            throw new AuraHandledException('注文もしくは注文明細の識別子が指定されていません。');
+        }
+
+        Http http = new Http();
+        HttpRequest request = new HttpRequest();
+        request.setEndpoint('callout:NovaRigel_Agentforce/agentforce/agents/NovaRigel_Returns_Agent/sessions');
+        request.setMethod('POST');
+        request.setHeader('Content-Type', 'application/json');
+
+        Map<String, Object> payload = new Map<String, Object>();
+        if (orderId != null) {
+            payload.put('orderId', orderId);
+        }
+        if (orderItemId != null) {
+            payload.put('orderItemId', orderItemId);
+        }
+
+        request.setBody(JSON.serialize(payload));
+
+        HttpResponse response = http.send(request);
+        Integer statusCode = response.getStatusCode();
+        if (statusCode >= 200 && statusCode < 300) {
+            String body = response.getBody();
+            if (String.isBlank(body)) {
+                return new ReturnsAgentSession();
+            }
+
+            return (ReturnsAgentSession) JSON.deserialize(body, ReturnsAgentSession.class);
+        }
+
+        String errorMessage = '返品・交換サポートの起動に失敗しました。(' + statusCode + ')';
+        if (!String.isBlank(response.getBody())) {
+            errorMessage += ' ' + response.getBody();
+        }
+
+        throw new AuraHandledException(errorMessage);
+    }
+}

--- a/force-app/main/default/classes/NovaRigelReturnsAgentController.cls-meta.xml
+++ b/force-app/main/default/classes/NovaRigelReturnsAgentController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/NovaRigelReturnsAgentControllerTest.cls
+++ b/force-app/main/default/classes/NovaRigelReturnsAgentControllerTest.cls
@@ -1,0 +1,72 @@
+@IsTest
+private class NovaRigelReturnsAgentControllerTest {
+    private class ReturnsAgentMock implements HttpCalloutMock {
+        private final Integer statusCode;
+        private final String body;
+
+        ReturnsAgentMock(Integer statusCode, String body) {
+            this.statusCode = statusCode;
+            this.body = body;
+        }
+
+        public HTTPResponse respond(HTTPRequest req) {
+            System.assertEquals(
+                'callout:NovaRigel_Agentforce/agentforce/agents/NovaRigel_Returns_Agent/sessions',
+                req.getEndpoint(),
+                'Unexpected endpoint.'
+            );
+            System.assertEquals('POST', req.getMethod(), 'HTTP method should be POST');
+
+            Map<String, Object> payload = (Map<String, Object>) JSON.deserializeUntyped(req.getBody());
+            System.assertEquals('001000000000001AAA', (String) payload.get('orderId'));
+            System.assertEquals('801000000000001AAA', (String) payload.get('orderItemId'));
+
+            HttpResponse res = new HttpResponse();
+            res.setStatusCode(statusCode);
+            res.setBody(body);
+            return res;
+        }
+    }
+
+    @IsTest
+    static void testLaunchReturnsAgentSuccess() {
+        Test.setMock(
+            HttpCalloutMock.class,
+            new ReturnsAgentMock(200, '{"sessionId":"session-123","launchUrl":"https://example.com","conversationId":"convo-001","message":"Launch"}')
+        );
+
+        Test.startTest();
+        NovaRigelReturnsAgentController.ReturnsAgentSession result =
+            NovaRigelReturnsAgentController.launchReturnsAgent(
+                Id.valueOf('001000000000001AAA'),
+                Id.valueOf('801000000000001AAA')
+            );
+        Test.stopTest();
+
+        System.assertEquals('session-123', result.sessionId);
+        System.assertEquals('https://example.com', result.launchUrl);
+        System.assertEquals('convo-001', result.conversationId);
+        System.assertEquals('Launch', result.message);
+    }
+
+    @IsTest
+    static void testLaunchReturnsAgentError() {
+        Test.setMock(HttpCalloutMock.class, new ReturnsAgentMock(500, 'Internal Error'));
+
+        Test.startTest();
+        Boolean exceptionThrown = false;
+        try {
+            NovaRigelReturnsAgentController.launchReturnsAgent(
+                Id.valueOf('001000000000001AAA'),
+                Id.valueOf('801000000000001AAA')
+            );
+        } catch (AuraHandledException e) {
+            exceptionThrown = true;
+            System.assert(e.getMessage().contains('返品・交換サポートの起動に失敗しました。'));
+            System.assert(e.getMessage().contains('500'));
+        }
+        Test.stopTest();
+
+        System.assertEquals(true, exceptionThrown, 'An AuraHandledException should have been thrown');
+    }
+}

--- a/force-app/main/default/classes/NovaRigelReturnsAgentControllerTest.cls-meta.xml
+++ b/force-app/main/default/classes/NovaRigelReturnsAgentControllerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/purchaseHistory/__tests__/purchaseHistory.test.js
+++ b/force-app/main/default/lwc/purchaseHistory/__tests__/purchaseHistory.test.js
@@ -1,0 +1,76 @@
+import { createElement } from 'lwc';
+import { ShowToastEventName } from 'lightning/platformShowToastEvent';
+import PurchaseHistory from 'c/purchaseHistory';
+
+jest.mock(
+    '@salesforce/apex/PurchaseHistoryController.getPurchaseHistory',
+    () => ({
+        default: jest.fn().mockResolvedValue([])
+    }),
+    { virtual: true }
+);
+
+const launchReturnsAgentMock = jest.fn().mockResolvedValue({
+    launchUrl: 'https://example.com/agent',
+    message: 'Launch message'
+});
+
+jest.mock(
+    '@salesforce/apex/NovaRigelReturnsAgentController.launchReturnsAgent',
+    () => ({
+        default: (...args) => launchReturnsAgentMock(...args)
+    }),
+    { virtual: true }
+);
+
+describe('c-purchase-history', () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it('invokes the returns agent Apex method when the button is clicked', async () => {
+        const element = createElement('c-purchase-history', {
+            is: PurchaseHistory
+        });
+        document.body.appendChild(element);
+
+        await Promise.resolve();
+
+        element.orders = [
+            {
+                orderId: '801000000000001AAA',
+                orderNumber: '00012345',
+                items: [
+                    {
+                        orderItemId: '802000000000001AAA',
+                        productName: 'テスト商品'
+                    }
+                ]
+            }
+        ];
+
+        await Promise.resolve();
+
+        const button = element.shadowRoot.querySelector(
+            'button[data-order-item-id="802000000000001AAA"]'
+        );
+        expect(button).not.toBeNull();
+
+        const handler = jest.fn();
+        element.addEventListener(ShowToastEventName, handler);
+
+        button.click();
+
+        await Promise.resolve();
+
+        expect(launchReturnsAgentMock).toHaveBeenCalledTimes(1);
+        expect(launchReturnsAgentMock.mock.calls[0][0]).toEqual({
+            orderId: '801000000000001AAA',
+            orderItemId: '802000000000001AAA'
+        });
+        expect(handler).toHaveBeenCalled();
+    });
+});

--- a/force-app/main/default/lwc/purchaseHistory/purchaseHistory.css
+++ b/force-app/main/default/lwc/purchaseHistory/purchaseHistory.css
@@ -3,6 +3,7 @@
 }
 
 .purchase-history {
+    position: relative;
     /* background-color: #f6f7f8; */
     padding: var(--lwc-spacingLarge, 1.5rem) var(--lwc-spacingMedium, 1rem);
 }
@@ -19,6 +20,13 @@
     justify-content: center;
     align-items: center;
     padding: var(--lwc-spacingXLarge, 2rem) 0;
+}
+
+.state--overlay {
+    position: absolute;
+    inset: 0;
+    background-color: rgba(255, 255, 255, 0.8);
+    z-index: 5;
 }
 
 .state--error {

--- a/force-app/main/default/lwc/purchaseHistory/purchaseHistory.html
+++ b/force-app/main/default/lwc/purchaseHistory/purchaseHistory.html
@@ -7,6 +7,12 @@
                 </div>
             </template>
 
+            <template if:true={isLaunchingAgent}>
+                <div class="state state--overlay">
+                    <lightning-spinner alternative-text="返品・交換サポートを起動中" size="small"></lightning-spinner>
+                </div>
+            </template>
+
             <template if:true={error}>
                 <div class="state state--error slds-notify slds-notify_alert slds-theme_alert-texture slds-theme_error" role="alert">
                     <span class="slds-assistive-text">エラー</span>
@@ -57,7 +63,19 @@
                                             </div>
                                             <div class="order-item__buttons">
                                                 <button class="item-action" type="button">商品を評価</button>
-                                                <button class="item-action" type="button">返品・交換</button>
+                                                <button
+                                                    class="item-action"
+                                                    type="button"
+                                                    onclick={handleReturnExchange}
+                                                    data-order-id={order.orderId}
+                                                    data-order-number={order.orderNumber}
+                                                    data-order-item-id={orderItem.orderItemId}
+                                                    data-product-name={orderItem.productName}
+                                                    disabled={isLaunchingAgent}
+                                                    aria-busy={isLaunchingAgent}
+                                                >
+                                                    返品・交換
+                                                </button>
                                             </div>
                                         </div>
                                     </li>

--- a/force-app/main/default/lwc/purchaseHistory/purchaseHistory.js
+++ b/force-app/main/default/lwc/purchaseHistory/purchaseHistory.js
@@ -1,12 +1,15 @@
 import { LightningElement, api } from 'lwc';
+import { NavigationMixin } from 'lightning/navigation';
 import getPurchaseHistory from '@salesforce/apex/PurchaseHistoryController.getPurchaseHistory';
+import launchReturnsAgent from '@salesforce/apex/NovaRigelReturnsAgentController.launchReturnsAgent';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 
-export default class PurchaseHistory extends LightningElement {
+export default class PurchaseHistory extends NavigationMixin(LightningElement) {
     @api recordId = '001gK00000KKvNCQA1';
     orders = [];
     error;
     isLoading = false;
+    isLaunchingAgent = false;
 
     connectedCallback() {
         this.loadPurchaseHistory();
@@ -50,6 +53,50 @@ export default class PurchaseHistory extends LightningElement {
             );
         } finally {
             this.isLoading = false;
+        }
+    }
+
+    async handleReturnExchange(event) {
+        const button = event.currentTarget;
+        const { orderId, orderItemId, orderNumber, productName } = button.dataset;
+        const contextLabel =
+            productName && orderNumber
+                ? `${productName}（注文番号: ${orderNumber}）`
+                : productName || (orderNumber ? `注文番号: ${orderNumber}` : '商品');
+
+        this.isLaunchingAgent = true;
+
+        try {
+            const response = await launchReturnsAgent({ orderId, orderItemId });
+
+            if (response?.launchUrl) {
+                this[NavigationMixin.Navigate]({
+                    type: 'standard__webPage',
+                    attributes: {
+                        url: response.launchUrl
+                    }
+                });
+            }
+
+            this.dispatchEvent(
+                new ShowToastEvent({
+                    title: '返品・交換サポート',
+                    message:
+                        response?.message ||
+                        `${contextLabel}の返品・交換サポートを開始しました。`,
+                    variant: 'success'
+                })
+            );
+        } catch (error) {
+            this.dispatchEvent(
+                new ShowToastEvent({
+                    title: '返品・交換サポートの起動に失敗しました',
+                    message: this.getErrorMessageFrom(error),
+                    variant: 'error'
+                })
+            );
+        } finally {
+            this.isLaunchingAgent = false;
         }
     }
 
@@ -206,5 +253,27 @@ export default class PurchaseHistory extends LightningElement {
         }
 
         return `商品数: ${this.formatNumber(value)}点`;
+    }
+
+    getErrorMessageFrom(error) {
+        const defaultMessage = '予期せぬエラーが発生しました。時間をおいて再度お試しください。';
+
+        if (!error) {
+            return defaultMessage;
+        }
+
+        if (Array.isArray(error.body)) {
+            return error.body.map((item) => item.message).join(', ');
+        }
+
+        if (typeof error.body?.message === 'string') {
+            return error.body.message;
+        }
+
+        if (typeof error.message === 'string') {
+            return error.message;
+        }
+
+        return defaultMessage;
     }
 }


### PR DESCRIPTION
## Summary
- add UI affordances and click handler wiring so purchase history can launch the returns agent
- create the NovaRigelReturnsAgentController Apex service plus tests and expose Agentforce launch details
- cover the new LWC behavior with a Jest unit test to ensure the Apex method is called

## Testing
- npm test *(fails: sfdx-lwc-jest not found; npm install blocked by 403 when fetching @lwc/eslint-plugin-lwc)*

------
https://chatgpt.com/codex/tasks/task_e_68dded9c9440832c832a3d9189d7259c