### PR TITLE
Refactor returns agent launch to embedded service

### DIFF
--- a/force-app/main/default/lwc/purchaseHistory/__tests__/purchaseHistory.test.js
+++ b/force-app/main/default/lwc/purchaseHistory/__tests__/purchaseHistory.test.js
@@ -65,11 +65,12 @@ describe('c-purchase-history', () => {
 
         expect(launchReturnsAgentUiMock).toHaveBeenCalledTimes(1);
         const launchArgs = launchReturnsAgentUiMock.mock.calls[0][0];
-        expect(launchArgs.context).toEqual({
-            orderId: '801000000000001AAA',
-            orderItemId: '802000000000001AAA'
+        expect(launchArgs).toEqual({
+            context: {
+                orderId: '801000000000001AAA',
+                orderItemId: '802000000000001AAA'
+            }
         });
-        expect(typeof launchArgs.navigate).toBe('function');
         expect(handler).toHaveBeenCalled();
     });
 });

--- a/force-app/main/default/lwc/purchaseHistory/purchaseHistory.js
+++ b/force-app/main/default/lwc/purchaseHistory/purchaseHistory.js
@@ -1,10 +1,9 @@
 import { LightningElement, api } from 'lwc';
-import { NavigationMixin } from 'lightning/navigation';
 import getPurchaseHistory from '@salesforce/apex/PurchaseHistoryController.getPurchaseHistory';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import { launchReturnsAgentUi } from 'c/returnsAgentLauncher';
 
-export default class PurchaseHistory extends NavigationMixin(LightningElement) {
+export default class PurchaseHistory extends LightningElement {
     @api recordId = '001gK00000KKvNCQA1';
     orders = [];
     error;
@@ -68,8 +67,7 @@ export default class PurchaseHistory extends NavigationMixin(LightningElement) {
 
         try {
             await launchReturnsAgentUi({
-                context: { orderId, orderItemId },
-                navigate: (pageReference) => this[NavigationMixin.Navigate](pageReference)
+                context: { orderId, orderItemId }
             });
 
             this.dispatchEvent(

--- a/force-app/main/default/lwc/returnsAgentLauncher/__tests__/returnsAgentLauncher.test.js
+++ b/force-app/main/default/lwc/returnsAgentLauncher/__tests__/returnsAgentLauncher.test.js
@@ -1,0 +1,90 @@
+import { launchReturnsAgentUi } from 'c/returnsAgentLauncher';
+
+describe('returnsAgentLauncher.launchReturnsAgentUi', () => {
+    afterEach(() => {
+        if (typeof window !== 'undefined') {
+            delete window.embedded_svc;
+        }
+    });
+
+    it('throws when no context is provided', async () => {
+        await expect(launchReturnsAgentUi()).rejects.toThrow(
+            '返品・交換サポートを起動するには注文または注文明細の識別子が必要です。'
+        );
+    });
+
+    it('throws when embedded service is not available', async () => {
+        await expect(
+            launchReturnsAgentUi({
+                context: { orderId: '801000000000001AAA' }
+            })
+        ).rejects.toThrow('返品・交換サポートの組み込みサービスが初期化されていません。');
+    });
+
+    it('starts a chat with prechat details when liveAgentAPI is available', async () => {
+        const startChat = jest.fn();
+
+        window.embedded_svc = {
+            settings: {
+                extraPrechatFormDetails: [
+                    { label: '既存情報', value: '保持する値', displayToAgent: true },
+                    { label: '注文ID', value: '上書き前', displayToAgent: true }
+                ]
+            },
+            liveAgentAPI: {
+                startChat
+            }
+        };
+
+        const result = await launchReturnsAgentUi({
+            context: {
+                orderId: '801000000000001AAA',
+                orderItemId: '802000000000001AAA'
+            }
+        });
+
+        expect(startChat).toHaveBeenCalledTimes(1);
+        expect(result).toEqual({
+            context: {
+                orderId: '801000000000001AAA',
+                orderItemId: '802000000000001AAA'
+            },
+            prechatDetails: [
+                { label: '注文ID', value: '801000000000001AAA', displayToAgent: true },
+                { label: '注文明細ID', value: '802000000000001AAA', displayToAgent: true }
+            ]
+        });
+        expect(window.embedded_svc.settings.extraPrechatFormDetails).toEqual([
+            { label: '注文ID', value: '801000000000001AAA', displayToAgent: true },
+            { label: '注文明細ID', value: '802000000000001AAA', displayToAgent: true },
+            { label: '既存情報', value: '保持する値', displayToAgent: true }
+        ]);
+    });
+
+    it('falls back to openChat when liveAgentAPI is unavailable', async () => {
+        const openChat = jest.fn(() => Promise.resolve());
+
+        window.embedded_svc = {
+            openChat
+        };
+
+        const result = await launchReturnsAgentUi({
+            context: {
+                orderItemId: '802000000000001AAA'
+            }
+        });
+
+        expect(openChat).toHaveBeenCalledTimes(1);
+        expect(result).toEqual({
+            context: {
+                orderItemId: '802000000000001AAA'
+            },
+            prechatDetails: [
+                { label: '注文明細ID', value: '802000000000001AAA', displayToAgent: true }
+            ]
+        });
+        expect(window.embedded_svc.settings.extraPrechatFormDetails).toEqual([
+            { label: '注文明細ID', value: '802000000000001AAA', displayToAgent: true }
+        ]);
+    });
+});

--- a/force-app/main/default/lwc/returnsAgentLauncher/returnsAgentLauncher.js
+++ b/force-app/main/default/lwc/returnsAgentLauncher/returnsAgentLauncher.js
@@ -1,55 +1,135 @@
-const WORKSPACE_BASE_URL = '/lightning/n/NovaRigel_Returns_Agent';
-const ORDER_ID_PARAM = 'c__orderId';
-const ORDER_ITEM_ID_PARAM = 'c__orderItemId';
+const EMBEDDED_SERVICE_GLOBAL = 'embedded_svc';
+const DEFAULT_DETAIL_LABELS = {
+    orderId: '注文ID',
+    orderItemId: '注文明細ID'
+};
 
 function isPromiseLike(value) {
     return value && typeof value.then === 'function';
 }
 
-export function buildReturnsAgentUrl(context = {}) {
-    const params = new URLSearchParams();
-    const { orderId, orderItemId } = context;
-
-    if (orderId) {
-        params.append(ORDER_ID_PARAM, orderId);
+function getWindowObject() {
+    if (typeof window === 'undefined') {
+        return undefined;
     }
 
-    if (orderItemId) {
-        params.append(ORDER_ITEM_ID_PARAM, orderItemId);
-    }
-
-    const queryString = params.toString();
-    return queryString ? `${WORKSPACE_BASE_URL}?${queryString}` : WORKSPACE_BASE_URL;
+    return window;
 }
 
-export function buildReturnsAgentPageReference(context = {}) {
+function resolveEmbeddedService(embeddedService) {
+    if (embeddedService) {
+        return embeddedService;
+    }
+
+    const win = getWindowObject();
+    const service = win ? win[EMBEDDED_SERVICE_GLOBAL] : undefined;
+
+    if (!service) {
+        throw new Error(
+            '返品・交換サポートの組み込みサービスが初期化されていません。'
+        );
+    }
+
+    return service;
+}
+
+function buildPrechatDetail(label, value) {
     return {
-        type: 'standard__webPage',
-        attributes: {
-            url: buildReturnsAgentUrl(context)
-        }
+        label,
+        value,
+        displayToAgent: true
     };
 }
 
-export async function launchReturnsAgentUi({ navigate, context } = {}) {
+function buildPrechatDetails(context = {}) {
+    return Object.entries(DEFAULT_DETAIL_LABELS)
+        .map(([key, label]) => ({ label, value: context[key] }))
+        .filter((detail) => detail.value)
+        .map(({ label, value }) => buildPrechatDetail(label, value));
+}
+
+function mergePrechatDetails(settings, details) {
+    if (!details.length) {
+        return [];
+    }
+
+    const existing = Array.isArray(settings.extraPrechatFormDetails)
+        ? settings.extraPrechatFormDetails
+        : settings.extraPrechatFormDetails
+        ? [settings.extraPrechatFormDetails]
+        : [];
+
+    const existingWithoutDuplicates = existing.filter((entry) => {
+        if (!entry || !entry.label) {
+            return true;
+        }
+
+        return !details.some((detail) => detail.label === entry.label);
+    });
+
+    const merged = [...details, ...existingWithoutDuplicates];
+    settings.extraPrechatFormDetails = merged;
+    return merged;
+}
+
+function getEmbeddedServiceSettings(service) {
+    if (!service.settings) {
+        service.settings = {};
+    }
+
+    return service.settings;
+}
+
+function openEmbeddedService(service) {
+    if (service.liveAgentAPI && typeof service.liveAgentAPI.startChat === 'function') {
+        const result = service.liveAgentAPI.startChat();
+        return isPromiseLike(result) ? result : Promise.resolve();
+    }
+
+    if (typeof service.openChat === 'function') {
+        const result = service.openChat();
+        return isPromiseLike(result) ? result : Promise.resolve();
+    }
+
+    if (typeof service.openHelp === 'function') {
+        const result = service.openHelp();
+        return isPromiseLike(result) ? result : Promise.resolve();
+    }
+
+    if (typeof service.bootstrapEmbeddedService === 'function') {
+        const result = service.bootstrapEmbeddedService();
+        return isPromiseLike(result) ? result : Promise.resolve();
+    }
+
+    throw new Error(
+        '返品・交換サポートを開始するための組み込みサービスが構成されていません。'
+    );
+}
+
+export async function launchReturnsAgentUi({ context, embeddedService } = {}) {
     if (!context || (!context.orderId && !context.orderItemId)) {
         throw new Error(
             '返品・交換サポートを起動するには注文または注文明細の識別子が必要です。'
         );
     }
 
-    const pageReference = buildReturnsAgentPageReference(context);
+    const service = resolveEmbeddedService(embeddedService);
+    const settings = getEmbeddedServiceSettings(service);
+    const prechatDetails = buildPrechatDetails(context);
 
-    if (typeof navigate === 'function') {
-        const navigationResult = navigate(pageReference);
-        if (isPromiseLike(navigationResult)) {
-            await navigationResult;
-        }
-    } else if (typeof window !== 'undefined' && typeof window.open === 'function') {
-        window.open(pageReference.attributes.url, '_blank', 'noopener');
-    } else {
-        throw new Error('Agentforce ワークスペースを開く方法が構成されていません。');
-    }
+    mergePrechatDetails(settings, prechatDetails);
+    await openEmbeddedService(service);
 
-    return pageReference;
+    return {
+        context,
+        prechatDetails
+    };
+}
+
+export function buildReturnsAgentUrl() {
+    throw new Error('Experience Cloud サイトでは直接URLに遷移できません。');
+}
+
+export function buildReturnsAgentPageReference() {
+    throw new Error('Experience Cloud サイトではLightningページ参照を生成しません。');
 }


### PR DESCRIPTION
## Summary
- switch the returns/exchange launcher to open the Experience Cloud embedded service instead of an internal workspace
- update the purchase history component to rely on the embedded service launcher and simplify the handler
- add unit coverage for the embedded service launcher and adjust the purchase history tests

## Testing
- npm run test:unit *(fails: sfdx-lwc-jest is unavailable because npm install is blocked by 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68de4fc4c2f8832caaadc2e7e8a32b38