### PR TITLE
Add guard for missing order context when launching returns agent

### DIFF
--- a/force-app/main/default/lwc/purchaseHistory/__tests__/purchaseHistory.test.js
+++ b/force-app/main/default/lwc/purchaseHistory/__tests__/purchaseHistory.test.js
@@ -73,4 +73,44 @@ describe('c-purchase-history', () => {
         });
         expect(handler).toHaveBeenCalled();
     });
+
+    it('shows an error toast when order context is missing', async () => {
+        const element = createElement('c-purchase-history', {
+            is: PurchaseHistory
+        });
+        document.body.appendChild(element);
+
+        await Promise.resolve();
+
+        element.orders = [
+            {
+                items: [
+                    {
+                        productName: '商品情報なし'
+                    }
+                ]
+            }
+        ];
+
+        await Promise.resolve();
+
+        const button = element.shadowRoot.querySelector('button.item-action');
+        expect(button).not.toBeNull();
+
+        const handler = jest.fn();
+        element.addEventListener(ShowToastEventName, handler);
+
+        button.click();
+
+        await Promise.resolve();
+
+        expect(launchReturnsAgentUiMock).not.toHaveBeenCalled();
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(handler.mock.calls[0][0].detail).toMatchObject({
+            title: '返品・交換サポート',
+            message:
+                '返品・交換対象の商品情報を取得できませんでした。時間をおいて再度お試しください。',
+            variant: 'error'
+        });
+    });
 });

--- a/force-app/main/default/lwc/purchaseHistory/purchaseHistory.js
+++ b/force-app/main/default/lwc/purchaseHistory/purchaseHistory.js
@@ -58,10 +58,23 @@ export default class PurchaseHistory extends LightningElement {
     async handleReturnExchange(event) {
         const button = event.currentTarget;
         const { orderId, orderItemId, orderNumber, productName } = button.dataset;
+        const hasOrderContext = Boolean(orderId || orderItemId);
         const contextLabel =
             productName && orderNumber
                 ? `${productName}（注文番号: ${orderNumber}）`
                 : productName || (orderNumber ? `注文番号: ${orderNumber}` : '商品');
+
+        if (!hasOrderContext) {
+            this.dispatchEvent(
+                new ShowToastEvent({
+                    title: '返品・交換サポート',
+                    message:
+                        '返品・交換対象の商品情報を取得できませんでした。時間をおいて再度お試しください。',
+                    variant: 'error'
+                })
+            );
+            return;
+        }
 
         this.isLaunchingAgent = true;
 


### PR DESCRIPTION
## Summary
- prevent launching the returns agent when the order item context is unavailable and surface a descriptive toast
- keep the existing launch flow unchanged when context is present
- add a unit test covering the missing-context path

## Testing
- npm test -- purchaseHistory *(fails: sfdx-lwc-jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68de6163d610832c8d03cb83eef5139e