### PR TITLE
Add Agentforce chat component for Experience Cloud

### DIFF
--- a/force-app/main/default/classes/AgentforceChatController.cls
+++ b/force-app/main/default/classes/AgentforceChatController.cls
@@ -1,0 +1,23 @@
+public with sharing class AgentforceChatController {
+    @AuraEnabled(cacheable=true)
+    public static AgentforceChatConfig getConfig() {
+        Agentforce_Config__mdt config = Agentforce_Config__mdt.getInstance('Default');
+        if (config == null) {
+            return new AgentforceChatConfig('', '');
+        }
+        return new AgentforceChatConfig(config.Endpoint_Url__c, config.Bot_Id__c);
+    }
+
+    public class AgentforceChatConfig {
+        @AuraEnabled
+        public String endpointUrl { get; set; }
+
+        @AuraEnabled
+        public String botId { get; set; }
+
+        public AgentforceChatConfig(String endpointUrl, String botId) {
+            this.endpointUrl = endpointUrl;
+            this.botId = botId;
+        }
+    }
+}

--- a/force-app/main/default/classes/AgentforceChatController.cls-meta.xml
+++ b/force-app/main/default/classes/AgentforceChatController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/customMetadata/Agentforce_Config.Default.md-meta.xml
+++ b/force-app/main/default/customMetadata/Agentforce_Config.Default.md-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata">
+    <label>Default</label>
+    <protected>false</protected>
+    <values>
+        <field>Bot_Id__c</field>
+        <value xsi:type="xsd:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">demo-bot</value>
+    </values>
+    <values>
+        <field>Endpoint_Url__c</field>
+        <value xsi:type="xsd:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">https://example.com/agentforce</value>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/lwc/agentforceChat/README.md
+++ b/force-app/main/default/lwc/agentforceChat/README.md
@@ -1,0 +1,24 @@
+# Agentforce Chat LWC
+
+This Lightning Web Component renders an Agentforce-powered chat experience for Experience Cloud sites and standard Lightning pages.
+
+## Setup
+
+1. **Deploy metadata**
+   - Deploy the `Agentforce_Config__mdt` custom metadata type, default record, Apex controller, and the `agentforceChat` LWC to your org.
+2. **Configure Agentforce connection**
+   - Update the `Agentforce_Config.Default` custom metadata record with your Agentforce endpoint URL and bot identifier. These values are read automatically when component properties are left blank.
+   - Optionally override the endpoint or bot ID per component instance through the Experience Builder property panel.
+3. **Experience Builder**
+   - In Experience Builder, open the desired page and drag the **Agentforce Chat** component from the custom components section onto the canvas.
+   - Publish the site after configuration.
+
+## Runtime behavior
+
+- Messages sent from the composer are posted to the configured Agentforce REST endpoint along with the existing transcript.
+- Agent responses are appended to the transcript when the API returns.
+- Errors are surfaced in the status banner and echoed into the transcript for quick diagnosis.
+
+## Testing
+
+Run `npm test agentforceChat` (or `npm test` for the full suite) to execute the Jest tests that verify message rendering and error-handling logic.

--- a/force-app/main/default/lwc/agentforceChat/__tests__/agentforceChat.test.js
+++ b/force-app/main/default/lwc/agentforceChat/__tests__/agentforceChat.test.js
@@ -1,0 +1,96 @@
+import { createElement } from 'lwc';
+import AgentforceChat from 'c/agentforceChat';
+import { registerApexTestWireAdapter } from '@salesforce/wire-service-jest-util';
+
+const mockGetConfig = jest.fn();
+
+jest.mock(
+    '@salesforce/apex/AgentforceChatController.getConfig',
+    () => ({
+        default: mockGetConfig
+    }),
+    { virtual: true }
+);
+
+const getConfigAdapter = registerApexTestWireAdapter(mockGetConfig);
+
+const flushPromises = () => new Promise(setImmediate);
+
+describe('c-agentforce-chat', () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it('renders messages from the user and Agentforce after send', async () => {
+        const element = createElement('c-agentforce-chat', {
+            is: AgentforceChat
+        });
+        element.endpointUrl = 'https://example.com/api';
+        element.botId = 'bot-123';
+        document.body.appendChild(element);
+
+        getConfigAdapter.emit({ endpointUrl: 'https://default.example.com', botId: 'default-bot' });
+
+        global.fetch = jest.fn().mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({ message: 'Hello from Agentforce' })
+        });
+
+        const textarea = element.shadowRoot.querySelector('lightning-textarea');
+        textarea.value = 'Hi there';
+        textarea.dispatchEvent(new CustomEvent('change'));
+
+        const button = element.shadowRoot.querySelector('lightning-button');
+        button.click();
+
+        await flushPromises();
+
+        expect(global.fetch).toHaveBeenCalledWith(
+            'https://example.com/api',
+            expect.objectContaining({
+                method: 'POST'
+            })
+        );
+
+        const userMessage = element.shadowRoot.querySelector('div[data-role="user"] .message-body');
+        expect(userMessage.textContent).toBe('Hi there');
+
+        const agentMessage = element.shadowRoot.querySelector('div[data-role="agent"] .message-body');
+        expect(agentMessage.textContent).toBe('Hello from Agentforce');
+    });
+
+    it('shows error state when the Agentforce call fails', async () => {
+        const element = createElement('c-agentforce-chat', {
+            is: AgentforceChat
+        });
+        element.endpointUrl = 'https://example.com/api';
+        element.botId = 'bot-123';
+        document.body.appendChild(element);
+
+        getConfigAdapter.emit({ endpointUrl: 'https://default.example.com', botId: 'default-bot' });
+
+        global.fetch = jest.fn().mockResolvedValue({
+            ok: false,
+            json: () => Promise.resolve({ message: 'Agentforce request failed' })
+        });
+
+        const textarea = element.shadowRoot.querySelector('lightning-textarea');
+        textarea.value = 'Hi there';
+        textarea.dispatchEvent(new CustomEvent('change'));
+
+        const button = element.shadowRoot.querySelector('lightning-button');
+        button.click();
+
+        await flushPromises();
+
+        const statusText = element.shadowRoot.querySelector('[data-id="status"] .status-text');
+        expect(statusText.textContent).toContain('Unable to send message');
+        expect(statusText.textContent).toContain('Agentforce request failed');
+
+        const agentMessage = element.shadowRoot.querySelector('div[data-role="agent"] .message-body');
+        expect(agentMessage.textContent).toBe('Agentforce request failed');
+    });
+});

--- a/force-app/main/default/lwc/agentforceChat/agentforceChat.css
+++ b/force-app/main/default/lwc/agentforceChat/agentforceChat.css
@@ -1,0 +1,82 @@
+.status {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.status-text {
+    font-size: 0.875rem;
+    color: var(--lwc-colorTextLabel, #514f4d);
+}
+
+.transcript {
+    min-height: 12rem;
+    max-height: 28rem;
+    overflow-y: auto;
+    padding: 0.75rem;
+    border: 1px solid var(--lwc-colorBorder, #dddbda);
+    border-radius: var(--lwc-borderRadiusMedium, 0.25rem);
+    background: var(--lwc-colorBackgroundAlt, #ffffff);
+    margin-bottom: 1rem;
+}
+
+.message-metadata {
+    font-size: 0.75rem;
+    color: var(--lwc-colorTextWeak, #706e6b);
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 0.25rem;
+}
+
+.message-body {
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.message {
+    padding: 0.5rem 0.75rem;
+    margin-bottom: 0.75rem;
+    border-radius: var(--lwc-borderRadiusMedium, 0.25rem);
+}
+
+.message.agent {
+    background: var(--lwc-colorBackgroundHighlight, #f3f2f2);
+}
+
+.message.user {
+    background: var(--lwc-colorBackgroundToastSuccess, #e3fcef);
+}
+
+.message.error {
+    border: 1px solid var(--lwc-colorBorderError, #ea001e);
+    color: var(--lwc-colorTextError, #ea001e);
+}
+
+.placeholder {
+    color: var(--lwc-colorTextWeak, #706e6b);
+    text-align: center;
+    margin: 2rem 0;
+}
+
+.composer {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.spin {
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
+.error {
+    color: var(--lwc-colorTextError, #ea001e);
+}

--- a/force-app/main/default/lwc/agentforceChat/agentforceChat.html
+++ b/force-app/main/default/lwc/agentforceChat/agentforceChat.html
@@ -1,0 +1,45 @@
+<template>
+    <lightning-card title="Agentforce Chat" icon-name="custom:custom14">
+        <div class="status" data-id="status">
+            <lightning-icon if:true={isLoading} icon-name="utility:refresh" alternative-text="Loading" class="spin"></lightning-icon>
+            <lightning-icon if:true={hasError} icon-name="utility:error" alternative-text="Error" class="error"></lightning-icon>
+            <template if:true={statusMessage}>
+                <span class="status-text">{statusMessage}</span>
+            </template>
+        </div>
+        <div class="transcript" data-id="transcript">
+            <template if:true={messages.length}>
+                <template for:each={messages} for:item="message">
+                    <div key={message.id} class={message.cssClass} data-role={message.role}>
+                        <div class="message-metadata">
+                            <span class="role">{message.roleLabel}</span>
+                            <span class="timestamp">{message.formattedTimestamp}</span>
+                        </div>
+                        <div class="message-body">{message.content}</div>
+                    </div>
+                </template>
+            </template>
+            <template if:false={messages.length}>
+                <p class="placeholder">No messages yet. Say hello to start the conversation.</p>
+            </template>
+        </div>
+        <div class="composer" data-id="composer">
+            <lightning-textarea
+                value={draftMessage}
+                onchange={handleDraftChange}
+                placeholder="Type your message..."
+                data-id="composer-input"
+                label="Your message"
+                maxlength="4000"
+            ></lightning-textarea>
+            <lightning-button
+                variant="brand"
+                label="Send"
+                onclick={handleSend}
+                disabled={isSendDisabled}
+                class="composer-send"
+                data-id="composer-send"
+            ></lightning-button>
+        </div>
+    </lightning-card>
+</template>

--- a/force-app/main/default/lwc/agentforceChat/agentforceChat.js
+++ b/force-app/main/default/lwc/agentforceChat/agentforceChat.js
@@ -1,0 +1,187 @@
+import { LightningElement, api, wire } from 'lwc';
+import getConfig from '@salesforce/apex/AgentforceChatController.getConfig';
+
+const ROLE_LABELS = {
+    user: 'You',
+    agent: 'Agentforce'
+};
+
+const STATUS = {
+    READY: 'Ready to chat',
+    SENDING: 'Sending message…',
+    ERROR: 'Unable to send message'
+};
+
+export default class AgentforceChat extends LightningElement {
+    _endpointUrl;
+    _botId;
+
+    @api
+    get endpointUrl() {
+        return this._endpointUrl;
+    }
+
+    set endpointUrl(value) {
+        this._endpointUrl = value;
+    }
+
+    @api
+    get botId() {
+        return this._botId;
+    }
+
+    set botId(value) {
+        this._botId = value;
+    }
+
+    messages = [];
+    draftMessage = '';
+    isLoading = false;
+    errorMessage;
+
+    wiredConfig;
+
+    @wire(getConfig)
+    wiredGetConfig(value) {
+        this.wiredConfig = value;
+        const { data, error } = value;
+        if (data) {
+            this.applyConfig(data);
+        } else if (error) {
+            this.errorMessage = 'Configuration error';
+            // eslint-disable-next-line no-console
+            console.error('AgentforceChat configuration error', error);
+        }
+    }
+
+    get statusMessage() {
+        if (this.errorMessage) {
+            return `${STATUS.ERROR}: ${this.errorMessage}`;
+        }
+        if (this.isLoading) {
+            return STATUS.SENDING;
+        }
+        return STATUS.READY;
+    }
+
+    get hasError() {
+        return Boolean(this.errorMessage);
+    }
+
+    get isSendDisabled() {
+        return !this.draftMessage || this.isLoading || !this.resolvedEndpoint;
+    }
+
+    get resolvedEndpoint() {
+        return this.endpointUrl || (this.wiredConfig?.data && this.wiredConfig.data.endpointUrl);
+    }
+
+    get resolvedBotId() {
+        return this.botId || (this.wiredConfig?.data && this.wiredConfig.data.botId);
+    }
+
+    applyConfig(data) {
+        if (!this.endpointUrl) {
+            this._endpointUrl = data.endpointUrl;
+        }
+        if (!this.botId) {
+            this._botId = data.botId;
+        }
+    }
+
+    handleDraftChange(event) {
+        this.draftMessage = event.target.value;
+    }
+
+    async handleSend() {
+        if (!this.draftMessage) {
+            return;
+        }
+
+        const userMessage = this.createMessage('user', this.draftMessage);
+        this.messages = [...this.messages, userMessage];
+        const draft = this.draftMessage;
+        this.draftMessage = '';
+        this.errorMessage = undefined;
+        this.isLoading = true;
+
+        try {
+            const response = await this.sendMessageToAgentforce(draft);
+            const agentResponse = this.createMessage('agent', response.message);
+            this.messages = [...this.messages, agentResponse];
+        } catch (error) {
+            this.errorMessage = this.normalizeError(error);
+            const errorMessage = this.createMessage('agent', this.errorMessage, 'error');
+            this.messages = [...this.messages, errorMessage];
+        } finally {
+            this.isLoading = false;
+        }
+    }
+
+    async sendMessageToAgentforce(content) {
+        const endpoint = this.resolvedEndpoint;
+        const botId = this.resolvedBotId;
+
+        if (!endpoint || !botId) {
+            throw new Error('Missing Agentforce configuration');
+        }
+
+        const payload = {
+            botId,
+            message: content,
+            transcript: this.messages.map((message) => ({
+                role: message.role,
+                content: message.content,
+                timestamp: message.timestamp
+            }))
+        };
+
+        const response = await fetch(endpoint, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(payload)
+        });
+
+        if (!response.ok) {
+            const errorBody = await response.json().catch(() => ({}));
+            throw new Error(errorBody.message || 'Agentforce request failed');
+        }
+
+        return response.json();
+    }
+
+    normalizeError(error) {
+        if (!error) {
+            return 'Unknown error';
+        }
+        if (typeof error === 'string') {
+            return error;
+        }
+        if (error.body && error.body.message) {
+            return error.body.message;
+        }
+        if (error.message) {
+            return error.message;
+        }
+        return 'Unexpected error';
+    }
+
+    createMessage(role, content, variant = '') {
+        const timestamp = new Date().toISOString();
+        return {
+            id: `${role}-${timestamp}-${Math.random().toString(36).slice(2, 10)}`,
+            role,
+            roleLabel: ROLE_LABELS[role] || role,
+            content,
+            timestamp,
+            formattedTimestamp: new Intl.DateTimeFormat('en-US', {
+                hour: 'numeric',
+                minute: 'numeric',
+                hour12: true
+            }).format(new Date(timestamp)),
+            cssClass: `message ${role}${variant ? ` ${variant}` : ''}`
+        };
+    }
+}

--- a/force-app/main/default/lwc/agentforceChat/agentforceChat.js-meta.xml
+++ b/force-app/main/default/lwc/agentforceChat/agentforceChat.js-meta.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <isExposed>true</isExposed>
+    <masterLabel>Agentforce Chat</masterLabel>
+    <targets>
+        <target>lightning__AppPage</target>
+        <target>lightning__HomePage</target>
+        <target>lightning__RecordPage</target>
+        <target>lightningCommunity__Page</target>
+        <target>lightningCommunity__Default</target>
+    </targets>
+    <targetConfigs>
+        <targetConfig targets="lightning__AppPage,lightning__RecordPage,lightning__HomePage,lightningCommunity__Page,lightningCommunity__Default">
+            <property name="endpointUrl" type="String" label="Agentforce Endpoint URL" description="REST endpoint that will receive chat messages." />
+            <property name="botId" type="String" label="Bot ID" description="Identifier for the Agentforce bot to contact." />
+        </targetConfig>
+    </targetConfigs>
+</LightningComponentBundle>

--- a/force-app/main/default/objects/Agentforce_Config__mdt/Agentforce_Config__mdt.object-meta.xml
+++ b/force-app/main/default/objects/Agentforce_Config__mdt/Agentforce_Config__mdt.object-meta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Configuration for Agentforce chat integration.</description>
+    <enableHistory>false</enableHistory>
+    <label>Agentforce Config</label>
+    <pluralLabel>Agentforce Configs</pluralLabel>
+    <visibility>Public</visibility>
+</CustomObject>

--- a/force-app/main/default/objects/Agentforce_Config__mdt/fields/Bot_Id__c.field-meta.xml
+++ b/force-app/main/default/objects/Agentforce_Config__mdt/fields/Bot_Id__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Bot_Id__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Bot Id</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Agentforce_Config__mdt/fields/Endpoint_Url__c.field-meta.xml
+++ b/force-app/main/default/objects/Agentforce_Config__mdt/fields/Endpoint_Url__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Endpoint_Url__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Endpoint Url</label>
+    <length>512</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
## Summary
- add a custom Agentforce chat Lightning Web Component with transcript UI, status indicators, and message composer exposed to Experience Cloud targets
- connect the component to the Agentforce REST endpoint via fetch with configuration defaults supplied by Apex and custom metadata
- deliver Jest coverage for rendering and error handling along with Experience Builder setup instructions

## Testing
- npm run test -- agentforceChat *(fails: sfdx-lwc-jest unavailable because npm install is blocked by registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_68de6b2302a0832c8d61e54a10520a02