### PR TITLE
Add Agentforce named credential callout support

### DIFF
--- a/force-app/main/default/classes/AgentforceChatController.cls
+++ b/force-app/main/default/classes/AgentforceChatController.cls
@@ -3,9 +3,110 @@ public with sharing class AgentforceChatController {
     public static AgentforceChatConfig getConfig() {
         Agentforce_Config__mdt config = Agentforce_Config__mdt.getInstance('Default');
         if (config == null) {
-            return new AgentforceChatConfig('', '');
+            return new AgentforceChatConfig('', '', '', '');
         }
-        return new AgentforceChatConfig(config.Endpoint_Url__c, config.Bot_Id__c);
+        return new AgentforceChatConfig(
+            config.Endpoint_Url__c,
+            config.Bot_Id__c,
+            config.Named_Credential__c,
+            config.Authorization_Header_Value__c
+        );
+    }
+
+    @AuraEnabled
+    public static AgentforceChatResponse sendMessage(
+        String message,
+        List<AgentforceChatTranscriptEntry> transcript,
+        String endpointUrl,
+        String botId
+    ) {
+        Agentforce_Config__mdt config = Agentforce_Config__mdt.getInstance('Default');
+
+        String resolvedEndpoint = String.isNotBlank(endpointUrl)
+            ? endpointUrl
+            : (config != null ? config.Endpoint_Url__c : null);
+        String resolvedBotId = String.isNotBlank(botId)
+            ? botId
+            : (config != null ? config.Bot_Id__c : null);
+        String namedCredential = config != null ? config.Named_Credential__c : null;
+        String authorizationHeader = config != null ? config.Authorization_Header_Value__c : null;
+
+        if (String.isBlank(resolvedEndpoint) || String.isBlank(resolvedBotId) || String.isBlank(namedCredential)) {
+            throw new AuraHandledException('Missing Agentforce configuration');
+        }
+
+        HttpRequest request = new HttpRequest();
+        request.setMethod('POST');
+        request.setEndpoint(buildCalloutEndpoint(namedCredential, resolvedEndpoint));
+        request.setHeader('Content-Type', 'application/json');
+        if (String.isNotBlank(authorizationHeader)) {
+            request.setHeader('Authorization', authorizationHeader);
+        }
+
+        Map<String, Object> payload = new Map<String, Object>{
+            'botId' => resolvedBotId,
+            'message' => message,
+            'transcript' => transcript != null ? transcript : new List<AgentforceChatTranscriptEntry>()
+        };
+        request.setBody(JSON.serialize(payload));
+
+        Http http = new Http();
+        HttpResponse response;
+        try {
+            response = http.send(request);
+        } catch (System.CalloutException ex) {
+            throw new AuraHandledException('Agentforce request failed: ' + ex.getMessage());
+        }
+
+        if (response.getStatusCode() >= 200 && response.getStatusCode() < 300) {
+            if (String.isBlank(response.getBody())) {
+                return new AgentforceChatResponse();
+            }
+            return (AgentforceChatResponse) JSON.deserialize(response.getBody(), AgentforceChatResponse.class);
+        }
+
+        String errorMessage = extractErrorMessage(response.getBody());
+        if (String.isBlank(errorMessage)) {
+            errorMessage = 'Agentforce request failed';
+        }
+        throw new AuraHandledException(errorMessage);
+    }
+
+    private static String buildCalloutEndpoint(String namedCredential, String endpointUrl) {
+        String trimmedEndpoint = endpointUrl == null ? '' : endpointUrl.trim();
+        if (startsWithIgnoreCase(trimmedEndpoint, 'http://') || startsWithIgnoreCase(trimmedEndpoint, 'https://')) {
+            Integer startOfPath = trimmedEndpoint.indexOf('/', trimmedEndpoint.indexOf('//') + 2);
+            trimmedEndpoint = startOfPath > -1 ? trimmedEndpoint.substring(startOfPath) : '';
+        }
+
+        if (String.isBlank(trimmedEndpoint)) {
+            return 'callout:' + namedCredential;
+        }
+
+        if (!trimmedEndpoint.startsWith('/')) {
+            trimmedEndpoint = '/' + trimmedEndpoint;
+        }
+
+        return 'callout:' + namedCredential + trimmedEndpoint;
+    }
+
+    private static String extractErrorMessage(String responseBody) {
+        if (String.isBlank(responseBody)) {
+            return null;
+        }
+
+        try {
+            AgentforceErrorResponse errorResponse = (AgentforceErrorResponse) JSON.deserialize(responseBody, AgentforceErrorResponse.class);
+            return errorResponse != null ? errorResponse.message : null;
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+
+    private static Boolean startsWithIgnoreCase(String value, String prefix) {
+        return String.isNotBlank(value)
+            && String.isNotBlank(prefix)
+            && value.toLowerCase().startsWith(prefix.toLowerCase());
     }
 
     public class AgentforceChatConfig {
@@ -15,9 +116,42 @@ public with sharing class AgentforceChatController {
         @AuraEnabled
         public String botId { get; set; }
 
-        public AgentforceChatConfig(String endpointUrl, String botId) {
+        @AuraEnabled
+        public String namedCredential { get; set; }
+
+        @AuraEnabled
+        public String authorizationHeaderValue { get; set; }
+
+        public AgentforceChatConfig(
+            String endpointUrl,
+            String botId,
+            String namedCredential,
+            String authorizationHeaderValue
+        ) {
             this.endpointUrl = endpointUrl;
             this.botId = botId;
+            this.namedCredential = namedCredential;
+            this.authorizationHeaderValue = authorizationHeaderValue;
         }
+    }
+
+    public class AgentforceChatTranscriptEntry {
+        @AuraEnabled
+        public String role { get; set; }
+
+        @AuraEnabled
+        public String content { get; set; }
+
+        @AuraEnabled
+        public String timestamp { get; set; }
+    }
+
+    public class AgentforceChatResponse {
+        @AuraEnabled
+        public String message { get; set; }
+    }
+
+    private class AgentforceErrorResponse {
+        public String message { get; set; }
     }
 }

--- a/force-app/main/default/customMetadata/Agentforce_Config.Default.md-meta.xml
+++ b/force-app/main/default/customMetadata/Agentforce_Config.Default.md-meta.xml
@@ -10,4 +10,12 @@
         <field>Endpoint_Url__c</field>
         <value xsi:type="xsd:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">https://example.com/agentforce</value>
     </values>
+    <values>
+        <field>Named_Credential__c</field>
+        <value xsi:type="xsd:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">Agentforce_Named_Credential</value>
+    </values>
+    <values>
+        <field>Authorization_Header_Value__c</field>
+        <value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+    </values>
 </CustomMetadata>

--- a/force-app/main/default/lwc/agentforceChat/README.md
+++ b/force-app/main/default/lwc/agentforceChat/README.md
@@ -6,10 +6,17 @@ This Lightning Web Component renders an Agentforce-powered chat experience for E
 
 1. **Deploy metadata**
    - Deploy the `Agentforce_Config__mdt` custom metadata type, default record, Apex controller, and the `agentforceChat` LWC to your org.
-2. **Configure Agentforce connection**
-   - Update the `Agentforce_Config.Default` custom metadata record with your Agentforce endpoint URL and bot identifier. These values are read automatically when component properties are left blank.
+2. **Configure Agentforce connection and authentication**
+   - Create a **Named Credential** that targets the Agentforce Agent API host (for example, `Agentforce_Named_Credential`). Store the API host URL in the Named Credential and, if using a static token, save it as a bearer token in the `Authorization` header value field described below. Grant the appropriate permission set so that the running user can access the Named Credential.
+   - Update the `Agentforce_Config.Default` custom metadata record with your API settings:
+     - `Endpoint Url` – the API path used for chat messages (for example, `/agentforce`). Absolute URLs are accepted; the controller will strip the host before performing the callout through the Named Credential.
+     - `Bot Id` – the Agentforce bot identifier to target.
+     - `Named Credential` – the API name of the Named Credential you created.
+     - `Authorization Header Value` – optional authorization header value (for example, `Bearer 00Dxxx!AQw...`). Leave blank when the Named Credential handles authentication automatically.
    - Optionally override the endpoint or bot ID per component instance through the Experience Builder property panel.
-3. **Experience Builder**
+3. **Assign permissions**
+   - Ensure that the running users have access to invoke the `AgentforceChatController` Apex class and read the `Agentforce_Config__mdt` metadata. Assign a permission set or profile that includes the Named Credential if it is marked as requiring explicit access.
+4. **Experience Builder**
    - In Experience Builder, open the desired page and drag the **Agentforce Chat** component from the custom components section onto the canvas.
    - Publish the site after configuration.
 

--- a/force-app/main/default/lwc/agentforceChat/__tests__/agentforceChat.test.js
+++ b/force-app/main/default/lwc/agentforceChat/__tests__/agentforceChat.test.js
@@ -3,11 +3,20 @@ import AgentforceChat from 'c/agentforceChat';
 import { registerApexTestWireAdapter } from '@salesforce/wire-service-jest-util';
 
 const mockGetConfig = jest.fn();
+const mockSendMessage = jest.fn();
 
 jest.mock(
     '@salesforce/apex/AgentforceChatController.getConfig',
     () => ({
         default: mockGetConfig
+    }),
+    { virtual: true }
+);
+
+jest.mock(
+    '@salesforce/apex/AgentforceChatController.sendMessage',
+    () => ({
+        default: mockSendMessage
     }),
     { virtual: true }
 );
@@ -34,10 +43,7 @@ describe('c-agentforce-chat', () => {
 
         getConfigAdapter.emit({ endpointUrl: 'https://default.example.com', botId: 'default-bot' });
 
-        global.fetch = jest.fn().mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ message: 'Hello from Agentforce' })
-        });
+        mockSendMessage.mockResolvedValue({ message: 'Hello from Agentforce' });
 
         const textarea = element.shadowRoot.querySelector('lightning-textarea');
         textarea.value = 'Hi there';
@@ -48,10 +54,11 @@ describe('c-agentforce-chat', () => {
 
         await flushPromises();
 
-        expect(global.fetch).toHaveBeenCalledWith(
-            'https://example.com/api',
+        expect(mockSendMessage).toHaveBeenCalledWith(
             expect.objectContaining({
-                method: 'POST'
+                message: 'Hi there',
+                endpointUrl: 'https://example.com/api',
+                botId: 'bot-123'
             })
         );
 
@@ -72,9 +79,8 @@ describe('c-agentforce-chat', () => {
 
         getConfigAdapter.emit({ endpointUrl: 'https://default.example.com', botId: 'default-bot' });
 
-        global.fetch = jest.fn().mockResolvedValue({
-            ok: false,
-            json: () => Promise.resolve({ message: 'Agentforce request failed' })
+        mockSendMessage.mockRejectedValue({
+            body: { message: 'Agentforce request failed' }
         });
 
         const textarea = element.shadowRoot.querySelector('lightning-textarea');

--- a/force-app/main/default/lwc/agentforceChat/agentforceChat.js
+++ b/force-app/main/default/lwc/agentforceChat/agentforceChat.js
@@ -1,5 +1,6 @@
 import { LightningElement, api, wire } from 'lwc';
 import getConfig from '@salesforce/apex/AgentforceChatController.getConfig';
+import sendMessage from '@salesforce/apex/AgentforceChatController.sendMessage';
 
 const ROLE_LABELS = {
     user: 'You',
@@ -107,7 +108,8 @@ export default class AgentforceChat extends LightningElement {
 
         try {
             const response = await this.sendMessageToAgentforce(draft);
-            const agentResponse = this.createMessage('agent', response.message);
+            const agentMessageText = response && response.message ? response.message : 'Agentforce response missing message.';
+            const agentResponse = this.createMessage('agent', agentMessageText);
             this.messages = [...this.messages, agentResponse];
         } catch (error) {
             this.errorMessage = this.normalizeError(error);
@@ -126,30 +128,16 @@ export default class AgentforceChat extends LightningElement {
             throw new Error('Missing Agentforce configuration');
         }
 
-        const payload = {
-            botId,
+        return sendMessage({
             message: content,
             transcript: this.messages.map((message) => ({
                 role: message.role,
                 content: message.content,
                 timestamp: message.timestamp
-            }))
-        };
-
-        const response = await fetch(endpoint, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify(payload)
+            })),
+            endpointUrl: endpoint,
+            botId
         });
-
-        if (!response.ok) {
-            const errorBody = await response.json().catch(() => ({}));
-            throw new Error(errorBody.message || 'Agentforce request failed');
-        }
-
-        return response.json();
     }
 
     normalizeError(error) {

--- a/force-app/main/default/objects/Agentforce_Config__mdt/fields/Authorization_Header_Value__c.field-meta.xml
+++ b/force-app/main/default/objects/Agentforce_Config__mdt/fields/Authorization_Header_Value__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Authorization_Header_Value__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Authorization Header Value</label>
+    <length>1024</length>
+    <required>false</required>
+    <type>TextArea</type>
+    <visibleLines>3</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/Agentforce_Config__mdt/fields/Named_Credential__c.field-meta.xml
+++ b/force-app/main/default/objects/Agentforce_Config__mdt/fields/Named_Credential__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Named_Credential__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Named Credential</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
## Summary
- add an Apex sendMessage callout that leverages the configured Named Credential and Authorization header
- extend the Agentforce configuration metadata and wire response to surface credential settings
- update the chat LWC, tests, and README to route messages through Apex and document authentication steps

## Testing
- npm test agentforceChat *(fails: sfdx-lwc-jest: not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1ca3c60a4832c8c3233b580a94e23