### PR TITLE
Implement OAuth token retrieval for Agentforce chat

### DIFF
--- a/force-app/main/default/classes/AgentforceChatController.cls
+++ b/force-app/main/default/classes/AgentforceChatController.cls
@@ -3,13 +3,17 @@ public with sharing class AgentforceChatController {
     public static AgentforceChatConfig getConfig() {
         Agentforce_Config__mdt config = Agentforce_Config__mdt.getInstance('Default');
         if (config == null) {
-            return new AgentforceChatConfig('', '', '', '');
+            return new AgentforceChatConfig('', '', '', '', '', '', '', '');
         }
         return new AgentforceChatConfig(
-            config.Endpoint_Url__c,
+            config.Chat_Endpoint_Url__c,
             config.Bot_Id__c,
-            config.Named_Credential__c,
-            config.Authorization_Header_Value__c
+            config.Authorization_Header_Value__c,
+            config.Endpoint_Url__c,
+            config.Consumer_Key__c,
+            config.Consumer_Secret__c,
+            config.Username__c,
+            config.Password__c
         );
     }
 
@@ -24,23 +28,47 @@ public with sharing class AgentforceChatController {
 
         String resolvedEndpoint = String.isNotBlank(endpointUrl)
             ? endpointUrl
-            : (config != null ? config.Endpoint_Url__c : null);
+            : (config != null ? config.Chat_Endpoint_Url__c : null);
         String resolvedBotId = String.isNotBlank(botId)
             ? botId
             : (config != null ? config.Bot_Id__c : null);
-        String namedCredential = config != null ? config.Named_Credential__c : null;
-        String authorizationHeader = config != null ? config.Authorization_Header_Value__c : null;
 
-        if (String.isBlank(resolvedEndpoint) || String.isBlank(resolvedBotId) || String.isBlank(namedCredential)) {
+        if (config == null) {
             throw new AuraHandledException('Missing Agentforce configuration');
         }
 
+        if (String.isBlank(resolvedEndpoint) || String.isBlank(resolvedBotId)) {
+            throw new AuraHandledException('Missing Agentforce configuration');
+        }
+
+        String tokenEndpoint = config.Endpoint_Url__c;
+        String consumerKey = config.Consumer_Key__c;
+        String consumerSecret = config.Consumer_Secret__c;
+        String usernameValue = config.Username__c;
+        String passwordValue = config.Password__c;
+
+        if (
+            String.isBlank(tokenEndpoint) || String.isBlank(consumerKey) || String.isBlank(consumerSecret)
+            || String.isBlank(usernameValue) || String.isBlank(passwordValue)
+        ) {
+            throw new AuraHandledException('Missing Agentforce OAuth configuration');
+        }
+
+        String accessToken = requestAccessToken(
+            tokenEndpoint,
+            consumerKey,
+            consumerSecret,
+            usernameValue,
+            passwordValue
+        );
+
         HttpRequest request = new HttpRequest();
         request.setMethod('POST');
-        request.setEndpoint(buildCalloutEndpoint(namedCredential, resolvedEndpoint));
+        request.setEndpoint(resolvedEndpoint);
         request.setHeader('Content-Type', 'application/json');
-        if (String.isNotBlank(authorizationHeader)) {
-            request.setHeader('Authorization', authorizationHeader);
+        request.setHeader('Authorization', 'Bearer ' + accessToken);
+        if (String.isNotBlank(config.Authorization_Header_Value__c)) {
+            request.setHeader('X-Agentforce-Authorization', config.Authorization_Header_Value__c);
         }
 
         Map<String, Object> payload = new Map<String, Object>{
@@ -72,30 +100,25 @@ public with sharing class AgentforceChatController {
         throw new AuraHandledException(errorMessage);
     }
 
-    private static String buildCalloutEndpoint(String namedCredential, String endpointUrl) {
-        String trimmedEndpoint = endpointUrl == null ? '' : endpointUrl.trim();
-        if (startsWithIgnoreCase(trimmedEndpoint, 'http://') || startsWithIgnoreCase(trimmedEndpoint, 'https://')) {
-            Integer startOfPath = trimmedEndpoint.indexOf('/', trimmedEndpoint.indexOf('//') + 2);
-            trimmedEndpoint = startOfPath > -1 ? trimmedEndpoint.substring(startOfPath) : '';
-        }
-
-        if (String.isBlank(trimmedEndpoint)) {
-            return 'callout:' + namedCredential;
-        }
-
-        if (!trimmedEndpoint.startsWith('/')) {
-            trimmedEndpoint = '/' + trimmedEndpoint;
-        }
-
-        return 'callout:' + namedCredential + trimmedEndpoint;
-    }
-
     private static String extractErrorMessage(String responseBody) {
         if (String.isBlank(responseBody)) {
             return null;
         }
 
         try {
+            Object parsed = JSON.deserializeUntyped(responseBody);
+            if (parsed instanceof Map<String, Object>) {
+                Map<String, Object> responseMap = (Map<String, Object>) parsed;
+                if (responseMap.containsKey('message') && responseMap.get('message') instanceof String) {
+                    return (String) responseMap.get('message');
+                }
+                if (responseMap.containsKey('error_description') && responseMap.get('error_description') instanceof String) {
+                    return (String) responseMap.get('error_description');
+                }
+                if (responseMap.containsKey('error') && responseMap.get('error') instanceof String) {
+                    return (String) responseMap.get('error');
+                }
+            }
             AgentforceErrorResponse errorResponse = (AgentforceErrorResponse) JSON.deserialize(responseBody, AgentforceErrorResponse.class);
             return errorResponse != null ? errorResponse.message : null;
         } catch (Exception ex) {
@@ -103,10 +126,62 @@ public with sharing class AgentforceChatController {
         }
     }
 
-    private static Boolean startsWithIgnoreCase(String value, String prefix) {
-        return String.isNotBlank(value)
-            && String.isNotBlank(prefix)
-            && value.toLowerCase().startsWith(prefix.toLowerCase());
+    private static String requestAccessToken(
+        String tokenEndpoint,
+        String consumerKey,
+        String consumerSecret,
+        String usernameValue,
+        String passwordValue
+    ) {
+        HttpRequest tokenRequest = new HttpRequest();
+        tokenRequest.setMethod('POST');
+        tokenRequest.setEndpoint(tokenEndpoint);
+        tokenRequest.setHeader('Content-Type', 'application/x-www-form-urlencoded');
+
+        String requestBody = String.join(new List<String>{
+            'grant_type=password',
+            'client_id=' + EncodingUtil.urlEncode(consumerKey, 'UTF-8'),
+            'client_secret=' + EncodingUtil.urlEncode(consumerSecret, 'UTF-8'),
+            'username=' + EncodingUtil.urlEncode(usernameValue, 'UTF-8'),
+            'password=' + EncodingUtil.urlEncode(passwordValue, 'UTF-8')
+        }, '&');
+        tokenRequest.setBody(requestBody);
+
+        Http http = new Http();
+        HttpResponse tokenResponse;
+        try {
+            tokenResponse = http.send(tokenRequest);
+        } catch (System.CalloutException ex) {
+            throw new AuraHandledException('Agentforce OAuth request failed: ' + ex.getMessage());
+        }
+
+        if (tokenResponse.getStatusCode() < 200 || tokenResponse.getStatusCode() >= 300) {
+            String tokenError = extractErrorMessage(tokenResponse.getBody());
+            if (String.isBlank(tokenError)) {
+                tokenError = 'Agentforce OAuth request failed';
+            }
+            throw new AuraHandledException(tokenError);
+        }
+
+        if (String.isBlank(tokenResponse.getBody())) {
+            throw new AuraHandledException('Agentforce OAuth response missing access token');
+        }
+
+        Object parsed = JSON.deserializeUntyped(tokenResponse.getBody());
+        if (!(parsed instanceof Map<String, Object>)) {
+            throw new AuraHandledException('Agentforce OAuth response malformed');
+        }
+
+        Map<String, Object> responseMap = (Map<String, Object>) parsed;
+        String accessToken = responseMap.containsKey('access_token')
+            ? (String) responseMap.get('access_token')
+            : null;
+
+        if (String.isBlank(accessToken)) {
+            throw new AuraHandledException('Agentforce OAuth response missing access token');
+        }
+
+        return accessToken;
     }
 
     public class AgentforceChatConfig {
@@ -117,21 +192,41 @@ public with sharing class AgentforceChatController {
         public String botId { get; set; }
 
         @AuraEnabled
-        public String namedCredential { get; set; }
+        public String authorizationHeaderValue { get; set; }
 
         @AuraEnabled
-        public String authorizationHeaderValue { get; set; }
+        public String tokenEndpointUrl { get; set; }
+
+        @AuraEnabled
+        public String consumerKey { get; set; }
+
+        @AuraEnabled
+        public String consumerSecret { get; set; }
+
+        @AuraEnabled
+        public String username { get; set; }
+
+        @AuraEnabled
+        public String password { get; set; }
 
         public AgentforceChatConfig(
             String endpointUrl,
             String botId,
-            String namedCredential,
-            String authorizationHeaderValue
+            String authorizationHeaderValue,
+            String tokenEndpointUrl,
+            String consumerKey,
+            String consumerSecret,
+            String username,
+            String password
         ) {
             this.endpointUrl = endpointUrl;
             this.botId = botId;
-            this.namedCredential = namedCredential;
             this.authorizationHeaderValue = authorizationHeaderValue;
+            this.tokenEndpointUrl = tokenEndpointUrl;
+            this.consumerKey = consumerKey;
+            this.consumerSecret = consumerSecret;
+            this.username = username;
+            this.password = password;
         }
     }
 

--- a/force-app/main/default/customMetadata/Agentforce_Config.Default.md-meta.xml
+++ b/force-app/main/default/customMetadata/Agentforce_Config.Default.md-meta.xml
@@ -8,14 +8,34 @@
     </values>
     <values>
         <field>Endpoint_Url__c</field>
+        <value xsi:type="xsd:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">https://example.com/oauth/token</value>
+    </values>
+    <values>
+        <field>Chat_Endpoint_Url__c</field>
         <value xsi:type="xsd:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">https://example.com/agentforce</value>
     </values>
     <values>
         <field>Named_Credential__c</field>
-        <value xsi:type="xsd:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">Agentforce_Named_Credential</value>
+        <value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
     </values>
     <values>
         <field>Authorization_Header_Value__c</field>
         <value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+    </values>
+    <values>
+        <field>Consumer_Key__c</field>
+        <value xsi:type="xsd:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">sample-client-key</value>
+    </values>
+    <values>
+        <field>Consumer_Secret__c</field>
+        <value xsi:type="xsd:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">sample-client-secret</value>
+    </values>
+    <values>
+        <field>Username__c</field>
+        <value xsi:type="xsd:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">agentforce-user@example.com</value>
+    </values>
+    <values>
+        <field>Password__c</field>
+        <value xsi:type="xsd:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">sample-password</value>
     </values>
 </CustomMetadata>

--- a/force-app/main/default/lwc/agentforceChat/README.md
+++ b/force-app/main/default/lwc/agentforceChat/README.md
@@ -7,22 +7,24 @@ This Lightning Web Component renders an Agentforce-powered chat experience for E
 1. **Deploy metadata**
    - Deploy the `Agentforce_Config__mdt` custom metadata type, default record, Apex controller, and the `agentforceChat` LWC to your org.
 2. **Configure Agentforce connection and authentication**
-   - Create a **Named Credential** that targets the Agentforce Agent API host (for example, `Agentforce_Named_Credential`). Store the API host URL in the Named Credential and, if using a static token, save it as a bearer token in the `Authorization` header value field described below. Grant the appropriate permission set so that the running user can access the Named Credential.
+   - Confirm that the OAuth and chat endpoints you plan to reach are added to Remote Site Settings (or otherwise permitted for callouts).
    - Update the `Agentforce_Config.Default` custom metadata record with your API settings:
-     - `Endpoint Url` – the API path used for chat messages (for example, `/agentforce`). Absolute URLs are accepted; the controller will strip the host before performing the callout through the Named Credential.
+     - `Chat Endpoint Url` – the REST endpoint that accepts chat messages (for example, `https://example.com/agentforce`). This value is used as the component default and can still be overridden per component instance in Experience Builder.
      - `Bot Id` – the Agentforce bot identifier to target.
-     - `Named Credential` – the API name of the Named Credential you created.
-     - `Authorization Header Value` – optional authorization header value (for example, `Bearer 00Dxxx!AQw...`). Leave blank when the Named Credential handles authentication automatically.
-   - Optionally override the endpoint or bot ID per component instance through the Experience Builder property panel.
+     - `Endpoint Url` – the OAuth token endpoint that issues access tokens (for example, `https://example.com/oauth/token`).
+     - `Consumer Key` and `Consumer Secret` – the client credentials for the OAuth connected app.
+     - `Username` and `Password` – the credentials of the Agentforce integration user. Include any required security token as part of the password value.
+     - `Authorization Header Value` – optional additional header value to include with the chat request. When populated, the value is sent in an `X-Agentforce-Authorization` header alongside the bearer token.
+   - Optionally override the chat endpoint or bot ID per component instance through the Experience Builder property panel.
 3. **Assign permissions**
-   - Ensure that the running users have access to invoke the `AgentforceChatController` Apex class and read the `Agentforce_Config__mdt` metadata. Assign a permission set or profile that includes the Named Credential if it is marked as requiring explicit access.
+   - Ensure that the running users have access to invoke the `AgentforceChatController` Apex class and read the `Agentforce_Config__mdt` metadata. Grant access to the Remote Site Settings (or other callout permissions) required for your integration.
 4. **Experience Builder**
    - In Experience Builder, open the desired page and drag the **Agentforce Chat** component from the custom components section onto the canvas.
    - Publish the site after configuration.
 
 ## Runtime behavior
 
-- Messages sent from the composer are posted to the configured Agentforce REST endpoint along with the existing transcript.
+- Messages sent from the composer are posted to the configured Agentforce REST endpoint along with the existing transcript. Before each chat callout, the controller performs the OAuth username-password flow using the stored credentials and passes the resulting bearer token to the chat service.
 - Agent responses are appended to the transcript when the API returns.
 - Errors are surfaced in the status banner and echoed into the transcript for quick diagnosis.
 

--- a/force-app/main/default/objects/Agentforce_Config__mdt/fields/Chat_Endpoint_Url__c.field-meta.xml
+++ b/force-app/main/default/objects/Agentforce_Config__mdt/fields/Chat_Endpoint_Url__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Chat_Endpoint_Url__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Chat Endpoint Url</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Agentforce_Config__mdt/fields/Consumer_Key__c.field-meta.xml
+++ b/force-app/main/default/objects/Agentforce_Config__mdt/fields/Consumer_Key__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Consumer_Key__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Consumer Key</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Agentforce_Config__mdt/fields/Consumer_Secret__c.field-meta.xml
+++ b/force-app/main/default/objects/Agentforce_Config__mdt/fields/Consumer_Secret__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Consumer_Secret__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Consumer Secret</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Agentforce_Config__mdt/fields/Password__c.field-meta.xml
+++ b/force-app/main/default/objects/Agentforce_Config__mdt/fields/Password__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Password__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Password</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Agentforce_Config__mdt/fields/Username__c.field-meta.xml
+++ b/force-app/main/default/objects/Agentforce_Config__mdt/fields/Username__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Username__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Username</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
## Summary
- extend the Agentforce configuration metadata with chat endpoint and OAuth credential fields along with default values
- update AgentforceChatController to retrieve an OAuth access token via the username-password flow and send chat requests with a bearer header
- refresh the Agentforce Chat README to describe configuring OAuth credentials in the custom metadata

## Testing
- npm test agentforceChat *(fails: sfdx-lwc-jest not found in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e26296ee84832c8d78307e55b848e5