### PR TITLE
Align chat flow with Agentforce session lifecycle

### DIFF
--- a/force-app/main/default/classes/AgentforceChatController.cls
+++ b/force-app/main/default/classes/AgentforceChatController.cls
@@ -1,252 +1,636 @@
 public with sharing class AgentforceChatController {
-    @AuraEnabled(cacheable=true)
-    public static AgentforceChatConfig getConfig() {
-        Agentforce_Config__mdt config = Agentforce_Config__mdt.getInstance('Default');
-        if (config == null) {
-            return new AgentforceChatConfig('', '', '', '', '', '', '', '');
-        }
-        return new AgentforceChatConfig(
-            config.Chat_Endpoint_Url__c,
-            config.Bot_Id__c,
-            config.Authorization_Header_Value__c,
-            config.Endpoint_Url__c,
-            config.Consumer_Key__c,
-            config.Consumer_Secret__c,
-            config.Username__c,
-            config.Password__c
-        );
+  @AuraEnabled(cacheable=true)
+  public static AgentforceChatConfig getConfig() {
+    Agentforce_Config__mdt config = Agentforce_Config__mdt.getInstance(
+      'Default'
+    );
+    if (config == null) {
+      return new AgentforceChatConfig('', '', '', '', '', '', '', '');
     }
+    return new AgentforceChatConfig(
+      config.Chat_Endpoint_Url__c,
+      config.Bot_Id__c,
+      config.Authorization_Header_Value__c,
+      config.Endpoint_Url__c,
+      config.Consumer_Key__c,
+      config.Consumer_Secret__c,
+      config.Username__c,
+      config.Password__c
+    );
+  }
+
+  @AuraEnabled
+  public static AgentforceChatResponse sendMessage(
+    String message,
+    List<AgentforceChatTranscriptEntry> transcript,
+    String endpointUrl,
+    String botId,
+    String sessionId
+  ) {
+    Agentforce_Config__mdt config = Agentforce_Config__mdt.getInstance(
+      'Default'
+    );
+
+    String resolvedEndpoint = String.isNotBlank(endpointUrl)
+      ? endpointUrl
+      : (config != null ? config.Chat_Endpoint_Url__c : null);
+    String resolvedBotId = String.isNotBlank(botId)
+      ? botId
+      : (config != null ? config.Bot_Id__c : null);
+
+    if (config == null) {
+      throw new AuraHandledException('Missing Agentforce configuration');
+    }
+
+    if (String.isBlank(resolvedEndpoint) || String.isBlank(resolvedBotId)) {
+      throw new AuraHandledException('Missing Agentforce configuration');
+    }
+
+    if (String.isBlank(sessionId)) {
+      throw new AuraHandledException('Missing Agentforce session');
+    }
+
+    String tokenEndpoint = config.Endpoint_Url__c;
+    String consumerKey = config.Consumer_Key__c;
+    String consumerSecret = config.Consumer_Secret__c;
+    String usernameValue = config.Username__c;
+    String passwordValue = config.Password__c;
+
+    if (
+      String.isBlank(tokenEndpoint) ||
+      String.isBlank(consumerKey) ||
+      String.isBlank(consumerSecret) ||
+      String.isBlank(usernameValue) ||
+      String.isBlank(passwordValue)
+    ) {
+      throw new AuraHandledException('Missing Agentforce OAuth configuration');
+    }
+
+    String accessToken = requestAccessToken(
+      tokenEndpoint,
+      consumerKey,
+      consumerSecret,
+      usernameValue,
+      passwordValue
+    );
+
+    HttpRequest request = new HttpRequest();
+    request.setMethod('POST');
+    request.setEndpoint(resolvedEndpoint);
+    request.setHeader('Content-Type', 'application/json');
+    request.setHeader('Authorization', 'Bearer ' + accessToken);
+    if (String.isNotBlank(config.Authorization_Header_Value__c)) {
+      request.setHeader(
+        'X-Agentforce-Authorization',
+        config.Authorization_Header_Value__c
+      );
+    }
+
+    Map<String, Object> payload = new Map<String, Object>{
+      'botId' => resolvedBotId,
+      'message' => message,
+      'sessionId' => sessionId,
+      'transcript' => transcript != null
+        ? transcript
+        : new List<AgentforceChatTranscriptEntry>()
+    };
+    request.setBody(JSON.serialize(payload));
+
+    Http http = new Http();
+    HttpResponse response;
+    try {
+      response = http.send(request);
+    } catch (System.CalloutException ex) {
+      throw new AuraHandledException(
+        'Agentforce request failed: ' + ex.getMessage()
+      );
+    }
+
+    if (response.getStatusCode() >= 200 && response.getStatusCode() < 300) {
+      if (String.isBlank(response.getBody())) {
+        return new AgentforceChatResponse();
+      }
+      return (AgentforceChatResponse) JSON.deserialize(
+        response.getBody(),
+        AgentforceChatResponse.class
+      );
+    }
+
+    String errorMessage = extractErrorMessage(response.getBody());
+    if (String.isBlank(errorMessage)) {
+      errorMessage = 'Agentforce request failed';
+    }
+    throw new AuraHandledException(errorMessage);
+  }
+
+  @AuraEnabled
+  public static AgentforceStartSessionResult startSession(
+    String endpointUrl,
+    Map<String, Object> payload
+  ) {
+    Agentforce_Config__mdt config = Agentforce_Config__mdt.getInstance(
+      'Default'
+    );
+
+    String resolvedEndpoint = String.isNotBlank(endpointUrl)
+      ? endpointUrl
+      : (config != null ? config.Chat_Endpoint_Url__c : null);
+
+    if (config == null) {
+      throw new AuraHandledException('Missing Agentforce configuration');
+    }
+
+    if (String.isBlank(resolvedEndpoint)) {
+      throw new AuraHandledException('Missing Agentforce configuration');
+    }
+
+    String tokenEndpoint = config.Endpoint_Url__c;
+    String consumerKey = config.Consumer_Key__c;
+    String consumerSecret = config.Consumer_Secret__c;
+    String usernameValue = config.Username__c;
+    String passwordValue = config.Password__c;
+
+    if (
+      String.isBlank(tokenEndpoint) ||
+      String.isBlank(consumerKey) ||
+      String.isBlank(consumerSecret) ||
+      String.isBlank(usernameValue) ||
+      String.isBlank(passwordValue)
+    ) {
+      throw new AuraHandledException('Missing Agentforce OAuth configuration');
+    }
+
+    String accessToken = requestAccessToken(
+      tokenEndpoint,
+      consumerKey,
+      consumerSecret,
+      usernameValue,
+      passwordValue
+    );
+
+    HttpRequest request = new HttpRequest();
+    request.setMethod('POST');
+    request.setEndpoint(resolvedEndpoint);
+    request.setHeader('Content-Type', 'application/json');
+    request.setHeader('Authorization', 'Bearer ' + accessToken);
+    if (String.isNotBlank(config.Authorization_Header_Value__c)) {
+      request.setHeader(
+        'X-Agentforce-Authorization',
+        config.Authorization_Header_Value__c
+      );
+    }
+
+    Map<String, Object> payloadToSend = payload != null
+      ? new Map<String, Object>(payload)
+      : new Map<String, Object>();
+    applyDefaultStartSessionPayload(payloadToSend);
+
+    String sessionKeyFromPayload = payloadToSend.containsKey('externalSessionKey') &&
+      payloadToSend.get('externalSessionKey') instanceof String
+      ? (String) payloadToSend.get('externalSessionKey')
+      : null;
+
+    request.setBody(JSON.serialize(payloadToSend));
+
+    Http http = new Http();
+    HttpResponse response;
+    try {
+      response = http.send(request);
+    } catch (System.CalloutException ex) {
+      throw new AuraHandledException(
+        'Agentforce request failed: ' + ex.getMessage()
+      );
+    }
+
+    if (response.getStatusCode() >= 200 && response.getStatusCode() < 300) {
+      AgentforceStartSessionResult result = new AgentforceStartSessionResult();
+      result.statusCode = response.getStatusCode();
+      result.externalSessionKey = sessionKeyFromPayload;
+      if (String.isNotBlank(response.getBody())) {
+        result.body = response.getBody();
+        Object parsed = JSON.deserializeUntyped(response.getBody());
+        if (parsed instanceof Map<String, Object>) {
+          result.data = (Map<String, Object>) parsed;
+          enrichStartSessionResult(result);
+        }
+      }
+      return result;
+    }
+
+    String errorMessage = extractErrorMessage(response.getBody());
+    if (String.isBlank(errorMessage)) {
+      errorMessage = 'Agentforce request failed';
+    }
+    throw new AuraHandledException(errorMessage);
+  }
+
+  private static String extractErrorMessage(String responseBody) {
+    if (String.isBlank(responseBody)) {
+      return null;
+    }
+
+    try {
+      Object parsed = JSON.deserializeUntyped(responseBody);
+      if (parsed instanceof Map<String, Object>) {
+        Map<String, Object> responseMap = (Map<String, Object>) parsed;
+        if (
+          responseMap.containsKey('message') &&
+          responseMap.get('message') instanceof String
+        ) {
+          return (String) responseMap.get('message');
+        }
+        if (
+          responseMap.containsKey('error_description') &&
+          responseMap.get('error_description') instanceof String
+        ) {
+          return (String) responseMap.get('error_description');
+        }
+        if (
+          responseMap.containsKey('error') &&
+          responseMap.get('error') instanceof String
+        ) {
+          return (String) responseMap.get('error');
+        }
+      }
+      AgentforceErrorResponse errorResponse = (AgentforceErrorResponse) JSON.deserialize(
+        responseBody,
+        AgentforceErrorResponse.class
+      );
+      return errorResponse != null ? errorResponse.message : null;
+    } catch (Exception ex) {
+      return null;
+    }
+  }
+
+  private static String requestAccessToken(
+    String tokenEndpoint,
+    String consumerKey,
+    String consumerSecret,
+    String usernameValue,
+    String passwordValue
+  ) {
+    HttpRequest tokenRequest = new HttpRequest();
+    tokenRequest.setMethod('POST');
+    tokenRequest.setEndpoint(tokenEndpoint);
+    tokenRequest.setHeader('Content-Type', 'application/x-www-form-urlencoded');
+
+    String requestBody = String.join(
+      new List<String>{
+        'grant_type=password',
+        'client_id=' + EncodingUtil.urlEncode(consumerKey, 'UTF-8'),
+        'client_secret=' + EncodingUtil.urlEncode(consumerSecret, 'UTF-8'),
+        'username=' + EncodingUtil.urlEncode(usernameValue, 'UTF-8'),
+        'password=' + EncodingUtil.urlEncode(passwordValue, 'UTF-8')
+      },
+      '&'
+    );
+    tokenRequest.setBody(requestBody);
+
+    Http http = new Http();
+    HttpResponse tokenResponse;
+    try {
+      tokenResponse = http.send(tokenRequest);
+    } catch (System.CalloutException ex) {
+      throw new AuraHandledException(
+        'Agentforce OAuth request failed: ' + ex.getMessage()
+      );
+    }
+
+    if (
+      tokenResponse.getStatusCode() < 200 ||
+      tokenResponse.getStatusCode() >= 300
+    ) {
+      String tokenError = extractErrorMessage(tokenResponse.getBody());
+      if (String.isBlank(tokenError)) {
+        tokenError = 'Agentforce OAuth request failed';
+      }
+      throw new AuraHandledException(tokenError);
+    }
+
+    if (String.isBlank(tokenResponse.getBody())) {
+      throw new AuraHandledException(
+        'Agentforce OAuth response missing access token'
+      );
+    }
+
+    Object parsed = JSON.deserializeUntyped(tokenResponse.getBody());
+    if (!(parsed instanceof Map<String, Object>)) {
+      throw new AuraHandledException('Agentforce OAuth response malformed');
+    }
+
+    Map<String, Object> responseMap = (Map<String, Object>) parsed;
+    String accessToken = responseMap.containsKey('access_token')
+      ? (String) responseMap.get('access_token')
+      : null;
+
+    if (String.isBlank(accessToken)) {
+      throw new AuraHandledException(
+        'Agentforce OAuth response missing access token'
+      );
+    }
+
+    return accessToken;
+  }
+
+  private static void applyDefaultStartSessionPayload(
+    Map<String, Object> payload
+  ) {
+    if (payload == null) {
+      return;
+    }
+
+    Object existingSessionKey = payload.get('externalSessionKey');
+    if (!(existingSessionKey instanceof String) || String.isBlank((String) existingSessionKey)) {
+      payload.put('externalSessionKey', generateExternalSessionKey());
+    }
+
+    Map<String, Object> instanceConfig = new Map<String, Object>();
+    if (
+      payload.containsKey('instanceConfig') &&
+      payload.get('instanceConfig') instanceof Map<String, Object>
+    ) {
+      instanceConfig.putAll((Map<String, Object>) payload.get('instanceConfig'));
+    }
+    if (
+      !instanceConfig.containsKey('endpoint') ||
+      !(instanceConfig.get('endpoint') instanceof String) ||
+      String.isBlank((String) instanceConfig.get('endpoint'))
+    ) {
+      try {
+        instanceConfig.put(
+          'endpoint',
+          URL.getSalesforceBaseUrl().toExternalForm()
+        );
+      } catch (Exception ex) {
+        // If the base URL cannot be resolved we leave the endpoint unset.
+      }
+    }
+    payload.put('instanceConfig', instanceConfig);
+
+    Object tzValue = payload.get('tz');
+    if (!(tzValue instanceof String) || String.isBlank((String) tzValue)) {
+      try {
+        payload.put('tz', UserInfo.getTimeZone().getID());
+      } catch (Exception ex) {
+        // Ignore and leave timezone unset when unavailable.
+      }
+    }
+
+    Boolean hasVariables =
+      payload.containsKey('variables') && payload.get('variables') instanceof List<Object> &&
+      !((List<Object>) payload.get('variables')).isEmpty();
+    if (!hasVariables) {
+      List<Object> variables = new List<Object>();
+      variables.add(
+        new Map<String, Object>{
+          'name' => '$Context.EndUserLanguage',
+          'type' => 'Text',
+          'value' => UserInfo.getLocale()
+        }
+      );
+      variables.add(
+        new Map<String, Object>{
+          'name' => '$Context.EndUser.Id',
+          'type' => 'Text',
+          'value' => UserInfo.getUserId()
+        }
+      );
+      variables.add(
+        new Map<String, Object>{
+          'name' => '$Context.EndUser.Type',
+          'type' => 'Text',
+          'value' => UserInfo.getUserType()
+        }
+      );
+      payload.put('variables', variables);
+    }
+
+    Object featureSupport = payload.get('featureSupport');
+    if (
+      !(featureSupport instanceof String) || String.isBlank((String) featureSupport)
+    ) {
+      payload.put('featureSupport', 'Streaming');
+    }
+
+    Map<String, Object> streamingCapabilities = new Map<String, Object>();
+    if (
+      payload.containsKey('streamingCapabilities') &&
+      payload.get('streamingCapabilities') instanceof Map<String, Object>
+    ) {
+      streamingCapabilities.putAll(
+        (Map<String, Object>) payload.get('streamingCapabilities')
+      );
+    }
+    Boolean hasChunkTypes =
+      streamingCapabilities.containsKey('chunkTypes') &&
+      streamingCapabilities.get('chunkTypes') instanceof List<Object> &&
+      !((List<Object>) streamingCapabilities.get('chunkTypes')).isEmpty();
+    if (!hasChunkTypes) {
+      streamingCapabilities.put('chunkTypes', new List<Object>{ 'Text' });
+    }
+    payload.put('streamingCapabilities', streamingCapabilities);
+  }
+
+  private static void enrichStartSessionResult(
+    AgentforceStartSessionResult result
+  ) {
+    if (result == null || result.data == null) {
+      return;
+    }
+
+    result.sessionId = preferString(
+      result.sessionId,
+      extractString(result.data, new List<String>{ 'sessionId', 'id' })
+    );
+    result.sessionUrl = preferString(
+      result.sessionUrl,
+      extractString(result.data, new List<String>{ 'sessionUrl', 'url' })
+    );
+    result.messagesUrl = preferString(
+      result.messagesUrl,
+      extractString(result.data, new List<String>{ 'messagesUrl' })
+    );
+
+    if (
+      result.data.containsKey('session') &&
+      result.data.get('session') instanceof Map<String, Object>
+    ) {
+      Map<String, Object> sessionMap = (Map<String, Object>) result.data.get(
+        'session'
+      );
+      result.sessionId = preferString(
+        result.sessionId,
+        extractString(sessionMap, new List<String>{ 'sessionId', 'id' })
+      );
+      result.sessionUrl = preferString(
+        result.sessionUrl,
+        extractString(sessionMap, new List<String>{ 'sessionUrl', 'url' })
+      );
+      result.messagesUrl = preferString(
+        result.messagesUrl,
+        extractString(sessionMap, new List<String>{ 'messagesUrl' })
+      );
+    }
+
+    if (
+      String.isBlank(result.messagesUrl) &&
+      String.isNotBlank(result.sessionUrl)
+    ) {
+      String normalizedSessionUrl = result.sessionUrl.endsWith('/messages')
+        ? result.sessionUrl
+        : result.sessionUrl + '/messages';
+      result.messagesUrl = normalizedSessionUrl;
+    }
+
+    if (
+      String.isBlank(result.messagesUrl) &&
+      String.isNotBlank(result.sessionId)
+    ) {
+      String baseSessionsUrl = extractString(
+        result.data,
+        new List<String>{ 'baseSessionsUrl', 'sessionsUrl', 'endpoint' }
+      );
+      if (String.isNotBlank(baseSessionsUrl)) {
+        result.messagesUrl = buildMessagesUrl(baseSessionsUrl, result.sessionId);
+      }
+    }
+  }
+
+  private static String buildMessagesUrl(String baseUrl, String sessionId) {
+    if (String.isBlank(baseUrl) || String.isBlank(sessionId)) {
+      return null;
+    }
+
+    String normalizedBase = baseUrl;
+    while (normalizedBase.endsWith('/')) {
+      normalizedBase = normalizedBase.substring(0, normalizedBase.length() - 1);
+    }
+    if (!normalizedBase.endsWith('/sessions')) {
+      normalizedBase = normalizedBase + '/sessions';
+    }
+
+    return normalizedBase +
+    '/' +
+    EncodingUtil.urlEncode(sessionId, 'UTF-8') +
+    '/messages';
+  }
+
+  private static String extractString(
+    Map<String, Object> source,
+    List<String> keys
+  ) {
+    if (source == null || keys == null) {
+      return null;
+    }
+    for (String key : keys) {
+      if (source.containsKey(key) && source.get(key) instanceof String) {
+        String value = (String) source.get(key);
+        if (String.isNotBlank(value)) {
+          return value;
+        }
+      }
+    }
+    return null;
+  }
+
+  private static String preferString(String currentValue, String candidate) {
+    return String.isNotBlank(currentValue) ? currentValue : candidate;
+  }
+
+  private static String generateExternalSessionKey() {
+    Blob randomBlob = Crypto.generateDigest(
+      'MD5',
+      Blob.valueOf(String.valueOf(Crypto.getRandomLong()))
+    );
+    return EncodingUtil.convertToHex(randomBlob);
+  }
+
+  public class AgentforceChatConfig {
+    @AuraEnabled
+    public String endpointUrl { get; set; }
 
     @AuraEnabled
-    public static AgentforceChatResponse sendMessage(
-        String message,
-        List<AgentforceChatTranscriptEntry> transcript,
-        String endpointUrl,
-        String botId
+    public String botId { get; set; }
+
+    @AuraEnabled
+    public String authorizationHeaderValue { get; set; }
+
+    @AuraEnabled
+    public String tokenEndpointUrl { get; set; }
+
+    @AuraEnabled
+    public String consumerKey { get; set; }
+
+    @AuraEnabled
+    public String consumerSecret { get; set; }
+
+    @AuraEnabled
+    public String username { get; set; }
+
+    @AuraEnabled
+    public String password { get; set; }
+
+    public AgentforceChatConfig(
+      String endpointUrl,
+      String botId,
+      String authorizationHeaderValue,
+      String tokenEndpointUrl,
+      String consumerKey,
+      String consumerSecret,
+      String username,
+      String password
     ) {
-        Agentforce_Config__mdt config = Agentforce_Config__mdt.getInstance('Default');
-
-        String resolvedEndpoint = String.isNotBlank(endpointUrl)
-            ? endpointUrl
-            : (config != null ? config.Chat_Endpoint_Url__c : null);
-        String resolvedBotId = String.isNotBlank(botId)
-            ? botId
-            : (config != null ? config.Bot_Id__c : null);
-
-        if (config == null) {
-            throw new AuraHandledException('Missing Agentforce configuration');
-        }
-
-        if (String.isBlank(resolvedEndpoint) || String.isBlank(resolvedBotId)) {
-            throw new AuraHandledException('Missing Agentforce configuration');
-        }
-
-        String tokenEndpoint = config.Endpoint_Url__c;
-        String consumerKey = config.Consumer_Key__c;
-        String consumerSecret = config.Consumer_Secret__c;
-        String usernameValue = config.Username__c;
-        String passwordValue = config.Password__c;
-
-        if (
-            String.isBlank(tokenEndpoint) || String.isBlank(consumerKey) || String.isBlank(consumerSecret)
-            || String.isBlank(usernameValue) || String.isBlank(passwordValue)
-        ) {
-            throw new AuraHandledException('Missing Agentforce OAuth configuration');
-        }
-
-        String accessToken = requestAccessToken(
-            tokenEndpoint,
-            consumerKey,
-            consumerSecret,
-            usernameValue,
-            passwordValue
-        );
-
-        HttpRequest request = new HttpRequest();
-        request.setMethod('POST');
-        request.setEndpoint(resolvedEndpoint);
-        request.setHeader('Content-Type', 'application/json');
-        request.setHeader('Authorization', 'Bearer ' + accessToken);
-        if (String.isNotBlank(config.Authorization_Header_Value__c)) {
-            request.setHeader('X-Agentforce-Authorization', config.Authorization_Header_Value__c);
-        }
-
-        Map<String, Object> payload = new Map<String, Object>{
-            'botId' => resolvedBotId,
-            'message' => message,
-            'transcript' => transcript != null ? transcript : new List<AgentforceChatTranscriptEntry>()
-        };
-        request.setBody(JSON.serialize(payload));
-
-        Http http = new Http();
-        HttpResponse response;
-        try {
-            response = http.send(request);
-        } catch (System.CalloutException ex) {
-            throw new AuraHandledException('Agentforce request failed: ' + ex.getMessage());
-        }
-
-        if (response.getStatusCode() >= 200 && response.getStatusCode() < 300) {
-            if (String.isBlank(response.getBody())) {
-                return new AgentforceChatResponse();
-            }
-            return (AgentforceChatResponse) JSON.deserialize(response.getBody(), AgentforceChatResponse.class);
-        }
-
-        String errorMessage = extractErrorMessage(response.getBody());
-        if (String.isBlank(errorMessage)) {
-            errorMessage = 'Agentforce request failed';
-        }
-        throw new AuraHandledException(errorMessage);
+      this.endpointUrl = endpointUrl;
+      this.botId = botId;
+      this.authorizationHeaderValue = authorizationHeaderValue;
+      this.tokenEndpointUrl = tokenEndpointUrl;
+      this.consumerKey = consumerKey;
+      this.consumerSecret = consumerSecret;
+      this.username = username;
+      this.password = password;
     }
+  }
 
-    private static String extractErrorMessage(String responseBody) {
-        if (String.isBlank(responseBody)) {
-            return null;
-        }
+  public class AgentforceChatTranscriptEntry {
+    @AuraEnabled
+    public String role { get; set; }
 
-        try {
-            Object parsed = JSON.deserializeUntyped(responseBody);
-            if (parsed instanceof Map<String, Object>) {
-                Map<String, Object> responseMap = (Map<String, Object>) parsed;
-                if (responseMap.containsKey('message') && responseMap.get('message') instanceof String) {
-                    return (String) responseMap.get('message');
-                }
-                if (responseMap.containsKey('error_description') && responseMap.get('error_description') instanceof String) {
-                    return (String) responseMap.get('error_description');
-                }
-                if (responseMap.containsKey('error') && responseMap.get('error') instanceof String) {
-                    return (String) responseMap.get('error');
-                }
-            }
-            AgentforceErrorResponse errorResponse = (AgentforceErrorResponse) JSON.deserialize(responseBody, AgentforceErrorResponse.class);
-            return errorResponse != null ? errorResponse.message : null;
-        } catch (Exception ex) {
-            return null;
-        }
-    }
+    @AuraEnabled
+    public String content { get; set; }
 
-    private static String requestAccessToken(
-        String tokenEndpoint,
-        String consumerKey,
-        String consumerSecret,
-        String usernameValue,
-        String passwordValue
-    ) {
-        HttpRequest tokenRequest = new HttpRequest();
-        tokenRequest.setMethod('POST');
-        tokenRequest.setEndpoint(tokenEndpoint);
-        tokenRequest.setHeader('Content-Type', 'application/x-www-form-urlencoded');
+    @AuraEnabled
+    public String timestamp { get; set; }
+  }
 
-        String requestBody = String.join(new List<String>{
-            'grant_type=password',
-            'client_id=' + EncodingUtil.urlEncode(consumerKey, 'UTF-8'),
-            'client_secret=' + EncodingUtil.urlEncode(consumerSecret, 'UTF-8'),
-            'username=' + EncodingUtil.urlEncode(usernameValue, 'UTF-8'),
-            'password=' + EncodingUtil.urlEncode(passwordValue, 'UTF-8')
-        }, '&');
-        tokenRequest.setBody(requestBody);
+  public class AgentforceChatResponse {
+    @AuraEnabled
+    public String message { get; set; }
+  }
 
-        Http http = new Http();
-        HttpResponse tokenResponse;
-        try {
-            tokenResponse = http.send(tokenRequest);
-        } catch (System.CalloutException ex) {
-            throw new AuraHandledException('Agentforce OAuth request failed: ' + ex.getMessage());
-        }
+  public class AgentforceStartSessionResult {
+    @AuraEnabled
+    public Integer statusCode { get; set; }
 
-        if (tokenResponse.getStatusCode() < 200 || tokenResponse.getStatusCode() >= 300) {
-            String tokenError = extractErrorMessage(tokenResponse.getBody());
-            if (String.isBlank(tokenError)) {
-                tokenError = 'Agentforce OAuth request failed';
-            }
-            throw new AuraHandledException(tokenError);
-        }
+    @AuraEnabled
+    public String body { get; set; }
 
-        if (String.isBlank(tokenResponse.getBody())) {
-            throw new AuraHandledException('Agentforce OAuth response missing access token');
-        }
+    @AuraEnabled
+    public Map<String, Object> data { get; set; }
 
-        Object parsed = JSON.deserializeUntyped(tokenResponse.getBody());
-        if (!(parsed instanceof Map<String, Object>)) {
-            throw new AuraHandledException('Agentforce OAuth response malformed');
-        }
+    @AuraEnabled
+    public String sessionId { get; set; }
 
-        Map<String, Object> responseMap = (Map<String, Object>) parsed;
-        String accessToken = responseMap.containsKey('access_token')
-            ? (String) responseMap.get('access_token')
-            : null;
+    @AuraEnabled
+    public String sessionUrl { get; set; }
 
-        if (String.isBlank(accessToken)) {
-            throw new AuraHandledException('Agentforce OAuth response missing access token');
-        }
+    @AuraEnabled
+    public String messagesUrl { get; set; }
 
-        return accessToken;
-    }
+    @AuraEnabled
+    public String externalSessionKey { get; set; }
+  }
 
-    public class AgentforceChatConfig {
-        @AuraEnabled
-        public String endpointUrl { get; set; }
-
-        @AuraEnabled
-        public String botId { get; set; }
-
-        @AuraEnabled
-        public String authorizationHeaderValue { get; set; }
-
-        @AuraEnabled
-        public String tokenEndpointUrl { get; set; }
-
-        @AuraEnabled
-        public String consumerKey { get; set; }
-
-        @AuraEnabled
-        public String consumerSecret { get; set; }
-
-        @AuraEnabled
-        public String username { get; set; }
-
-        @AuraEnabled
-        public String password { get; set; }
-
-        public AgentforceChatConfig(
-            String endpointUrl,
-            String botId,
-            String authorizationHeaderValue,
-            String tokenEndpointUrl,
-            String consumerKey,
-            String consumerSecret,
-            String username,
-            String password
-        ) {
-            this.endpointUrl = endpointUrl;
-            this.botId = botId;
-            this.authorizationHeaderValue = authorizationHeaderValue;
-            this.tokenEndpointUrl = tokenEndpointUrl;
-            this.consumerKey = consumerKey;
-            this.consumerSecret = consumerSecret;
-            this.username = username;
-            this.password = password;
-        }
-    }
-
-    public class AgentforceChatTranscriptEntry {
-        @AuraEnabled
-        public String role { get; set; }
-
-        @AuraEnabled
-        public String content { get; set; }
-
-        @AuraEnabled
-        public String timestamp { get; set; }
-    }
-
-    public class AgentforceChatResponse {
-        @AuraEnabled
-        public String message { get; set; }
-    }
-
-    private class AgentforceErrorResponse {
-        public String message { get; set; }
-    }
+  private class AgentforceErrorResponse {
+    public String message { get; set; }
+  }
 }

--- a/force-app/main/default/lwc/agentforceChat/__tests__/agentforceChat.test.js
+++ b/force-app/main/default/lwc/agentforceChat/__tests__/agentforceChat.test.js
@@ -3,6 +3,7 @@ import AgentforceChat from 'c/agentforceChat';
 import { registerApexTestWireAdapter } from '@salesforce/wire-service-jest-util';
 
 const mockGetConfig = jest.fn();
+const mockStartSession = jest.fn();
 const mockSendMessage = jest.fn();
 
 jest.mock(
@@ -14,9 +15,41 @@ jest.mock(
 );
 
 jest.mock(
+    '@salesforce/apex/AgentforceChatController.startSession',
+    () => ({
+        default: mockStartSession
+    }),
+    { virtual: true }
+);
+
+jest.mock(
     '@salesforce/apex/AgentforceChatController.sendMessage',
     () => ({
         default: mockSendMessage
+    }),
+    { virtual: true }
+);
+
+jest.mock(
+    '@salesforce/user/Id',
+    () => ({
+        default: '005000000000001'
+    }),
+    { virtual: true }
+);
+
+jest.mock(
+    '@salesforce/i18n/locale',
+    () => ({
+        default: 'en_US'
+    }),
+    { virtual: true }
+);
+
+jest.mock(
+    '@salesforce/i18n/timeZone',
+    () => ({
+        default: 'America/Los_Angeles'
     }),
     { virtual: true }
 );
@@ -43,6 +76,11 @@ describe('c-agentforce-chat', () => {
 
         getConfigAdapter.emit({ endpointUrl: 'https://default.example.com', botId: 'default-bot' });
 
+        mockStartSession.mockResolvedValue({
+            sessionId: 'session-123',
+            messagesUrl: 'https://example.com/api/sessions/session-123/messages',
+            externalSessionKey: 'abc'
+        });
         mockSendMessage.mockResolvedValue({ message: 'Hello from Agentforce' });
 
         const textarea = element.shadowRoot.querySelector('lightning-textarea');
@@ -53,12 +91,20 @@ describe('c-agentforce-chat', () => {
         button.click();
 
         await flushPromises();
+        await flushPromises();
+
+        expect(mockStartSession).toHaveBeenCalledWith(
+            expect.objectContaining({
+                endpointUrl: 'https://example.com/api'
+            })
+        );
 
         expect(mockSendMessage).toHaveBeenCalledWith(
             expect.objectContaining({
                 message: 'Hi there',
-                endpointUrl: 'https://example.com/api',
-                botId: 'bot-123'
+                endpointUrl: 'https://example.com/api/sessions/session-123/messages',
+                botId: 'bot-123',
+                sessionId: 'session-123'
             })
         );
 
@@ -79,6 +125,10 @@ describe('c-agentforce-chat', () => {
 
         getConfigAdapter.emit({ endpointUrl: 'https://default.example.com', botId: 'default-bot' });
 
+        mockStartSession.mockResolvedValue({
+            sessionId: 'session-123',
+            messagesUrl: 'https://example.com/api/sessions/session-123/messages'
+        });
         mockSendMessage.mockRejectedValue({
             body: { message: 'Agentforce request failed' }
         });
@@ -90,6 +140,7 @@ describe('c-agentforce-chat', () => {
         const button = element.shadowRoot.querySelector('lightning-button');
         button.click();
 
+        await flushPromises();
         await flushPromises();
 
         const statusText = element.shadowRoot.querySelector('[data-id="status"] .status-text');

--- a/force-app/main/default/lwc/agentforceChat/agentforceChat.js
+++ b/force-app/main/default/lwc/agentforceChat/agentforceChat.js
@@ -1,6 +1,10 @@
 import { LightningElement, api, wire } from 'lwc';
 import getConfig from '@salesforce/apex/AgentforceChatController.getConfig';
+import startSession from '@salesforce/apex/AgentforceChatController.startSession';
 import sendMessage from '@salesforce/apex/AgentforceChatController.sendMessage';
+import USER_ID from '@salesforce/user/Id';
+import USER_LOCALE from '@salesforce/i18n/locale';
+import USER_TIMEZONE from '@salesforce/i18n/timeZone';
 
 const ROLE_LABELS = {
     user: 'You',
@@ -39,6 +43,10 @@ export default class AgentforceChat extends LightningElement {
     draftMessage = '';
     isLoading = false;
     errorMessage;
+    sessionId;
+    sessionKey;
+    messagesEndpoint;
+    sessionInitializationPromise;
 
     wiredConfig;
 
@@ -81,6 +89,17 @@ export default class AgentforceChat extends LightningElement {
         return this.botId || (this.wiredConfig?.data && this.wiredConfig.data.botId);
     }
 
+    get resolvedInstanceEndpoint() {
+        if (typeof window === 'undefined' || !window.location) {
+            return undefined;
+        }
+        return window.location.origin;
+    }
+
+    get resolvedStartSessionEndpoint() {
+        return this.resolvedEndpoint;
+    }
+
     applyConfig(data) {
         if (!this.endpointUrl) {
             this._endpointUrl = data.endpointUrl;
@@ -121,11 +140,16 @@ export default class AgentforceChat extends LightningElement {
     }
 
     async sendMessageToAgentforce(content) {
-        const endpoint = this.resolvedEndpoint;
         const botId = this.resolvedBotId;
 
-        if (!endpoint || !botId) {
+        if (!botId) {
             throw new Error('Missing Agentforce configuration');
+        }
+
+        await this.ensureSession();
+
+        if (!this.messagesEndpoint) {
+            throw new Error('Missing Agentforce session endpoint');
         }
 
         return sendMessage({
@@ -135,9 +159,184 @@ export default class AgentforceChat extends LightningElement {
                 content: message.content,
                 timestamp: message.timestamp
             })),
-            endpointUrl: endpoint,
-            botId
+            endpointUrl: this.messagesEndpoint,
+            botId,
+            sessionId: this.sessionId
         });
+    }
+
+    async ensureSession() {
+        if (this.sessionId && this.messagesEndpoint) {
+            return;
+        }
+
+        if (this.sessionInitializationPromise) {
+            return this.sessionInitializationPromise;
+        }
+
+        this.sessionInitializationPromise = this.initializeSession();
+
+        try {
+            await this.sessionInitializationPromise;
+        } finally {
+            this.sessionInitializationPromise = undefined;
+        }
+    }
+
+    async initializeSession() {
+        const endpoint = this.resolvedStartSessionEndpoint;
+        if (!endpoint) {
+            throw new Error('Missing Agentforce configuration');
+        }
+
+        const payload = this.buildStartSessionPayload();
+        const result = await startSession({ endpointUrl: endpoint, payload });
+
+        const sessionId = this.extractSessionId(result);
+        if (!sessionId) {
+            throw new Error('Agentforce session did not return an identifier');
+        }
+
+        this.sessionId = sessionId;
+        this.sessionKey = result?.externalSessionKey || payload.externalSessionKey;
+        this.messagesEndpoint = this.resolveMessagesEndpoint(result, sessionId, endpoint);
+    }
+
+    buildStartSessionPayload() {
+        const sessionKey = this.sessionKey || this.generateExternalSessionKey();
+        const payload = {
+            externalSessionKey: sessionKey,
+            instanceConfig: {
+                endpoint: this.resolvedInstanceEndpoint
+            },
+            tz: USER_TIMEZONE || this.getBrowserTimeZone(),
+            variables: [
+                {
+                    name: '$Context.EndUserLanguage',
+                    type: 'Text',
+                    value: this.normalizeLocale(USER_LOCALE)
+                },
+                {
+                    name: '$Context.EndUser.Id',
+                    type: 'Text',
+                    value: USER_ID
+                },
+                {
+                    name: '$Context.EndUser.Type',
+                    type: 'Text',
+                    value: 'SalesforceUser'
+                }
+            ],
+            featureSupport: 'Streaming',
+            streamingCapabilities: {
+                chunkTypes: ['Text']
+            }
+        };
+        return payload;
+    }
+
+    extractSessionId(result) {
+        if (!result) {
+            return undefined;
+        }
+        if (result.sessionId) {
+            return result.sessionId;
+        }
+        if (result.data) {
+            if (result.data.sessionId) {
+                return result.data.sessionId;
+            }
+            if (result.data.id) {
+                return result.data.id;
+            }
+            if (result.data.session && typeof result.data.session === 'object') {
+                const session = result.data.session;
+                if (session.sessionId) {
+                    return session.sessionId;
+                }
+                if (session.id) {
+                    return session.id;
+                }
+            }
+        }
+        return undefined;
+    }
+
+    resolveMessagesEndpoint(result, sessionId, startEndpoint) {
+        if (result?.messagesUrl) {
+            return result.messagesUrl;
+        }
+        if (result?.sessionUrl) {
+            return this.appendPath(result.sessionUrl, 'messages');
+        }
+        if (result?.data?.messagesUrl) {
+            return result.data.messagesUrl;
+        }
+        if (result?.data?.session && typeof result.data.session === 'object') {
+            const session = result.data.session;
+            if (session.messagesUrl) {
+                return session.messagesUrl;
+            }
+            if (session.sessionUrl) {
+                return this.appendPath(session.sessionUrl, 'messages');
+            }
+            if (session.url) {
+                return this.appendPath(session.url, 'messages');
+            }
+        }
+
+        return this.buildMessagesEndpointFromBase(startEndpoint, sessionId);
+    }
+
+    buildMessagesEndpointFromBase(baseEndpoint, sessionId) {
+        if (!baseEndpoint || !sessionId) {
+            return undefined;
+        }
+
+        let normalized = baseEndpoint.replace(/\/+$/, '');
+        if (!normalized.endsWith('/sessions')) {
+            normalized = `${normalized}/sessions`;
+        }
+        return `${normalized}/${encodeURIComponent(sessionId)}/messages`;
+    }
+
+    appendPath(base, segment) {
+        if (!base) {
+            return undefined;
+        }
+        const trimmed = base.replace(/\/+$/, '');
+        return `${trimmed}/${segment}`;
+    }
+
+    generateExternalSessionKey() {
+        const array = new Uint32Array(4);
+        const hasWindow = typeof window !== 'undefined';
+        const cryptoProvider = hasWindow ? window.crypto : undefined;
+        if (cryptoProvider && typeof cryptoProvider.getRandomValues === 'function') {
+            cryptoProvider.getRandomValues(array);
+        } else {
+            for (let index = 0; index < array.length; index += 1) {
+                array[index] = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
+            }
+        }
+        return Array.from(array)
+            .map((value) => value.toString(16).padStart(8, '0'))
+            .join('');
+    }
+
+    normalizeLocale(locale) {
+        if (!locale || typeof locale !== 'string') {
+            return 'en_US';
+        }
+        return locale.replace('-', '_');
+    }
+
+    getBrowserTimeZone() {
+        try {
+            return Intl.DateTimeFormat().resolvedOptions().timeZone;
+        } catch (error) {
+            return 'UTC';
+        }
     }
 
     normalizeError(error) {


### PR DESCRIPTION
## Summary
- require a valid Agentforce session identifier when sending chat messages and propagate it to the API payload
- create start session requests with sensible defaults, capture the returned identifiers, and surface message endpoints to callers
- update the Lightning web component to negotiate Agentforce sessions before sending messages and expand unit tests to cover the new flow

## Testing
- npm test -- agentforceChat *(fails: sfdx-lwc-jest not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eb74b444d4832ca21c55582a593e64