### PR TITLE
Add configurable endpoints for Agentforce session and message calls

### DIFF
--- a/force-app/main/default/classes/AgentforceChatController.cls
+++ b/force-app/main/default/classes/AgentforceChatController.cls
@@ -5,10 +5,21 @@ public with sharing class AgentforceChatController {
       'Default'
     );
     if (config == null) {
-      return new AgentforceChatConfig('', '', '', '', '', '', '', '');
+      return new AgentforceChatConfig('', '', '', '', '', '', '', '', '');
     }
+    String startSessionEndpoint = config.Start_Session_Endpoint_Url__c;
+    if (String.isBlank(startSessionEndpoint)) {
+      startSessionEndpoint = config.Chat_Endpoint_Url__c;
+    }
+
+    String messagesEndpoint = config.Messages_Endpoint_Url__c;
+    if (String.isBlank(messagesEndpoint)) {
+      messagesEndpoint = config.Chat_Endpoint_Url__c;
+    }
+
     return new AgentforceChatConfig(
-      config.Chat_Endpoint_Url__c,
+      startSessionEndpoint,
+      messagesEndpoint,
       config.Bot_Id__c,
       config.Authorization_Header_Value__c,
       config.Endpoint_Url__c,
@@ -31,9 +42,13 @@ public with sharing class AgentforceChatController {
       'Default'
     );
 
+    String configuredMessagesEndpoint = config != null
+      ? preferString(config.Messages_Endpoint_Url__c, config.Chat_Endpoint_Url__c)
+      : null;
+
     String resolvedEndpoint = String.isNotBlank(endpointUrl)
       ? endpointUrl
-      : (config != null ? config.Chat_Endpoint_Url__c : null);
+      : configuredMessagesEndpoint;
     String resolvedBotId = String.isNotBlank(botId)
       ? botId
       : (config != null ? config.Bot_Id__c : null);
@@ -145,9 +160,13 @@ public with sharing class AgentforceChatController {
       'Default'
     );
 
+    String configuredStartSessionEndpoint = config != null
+      ? preferString(config.Start_Session_Endpoint_Url__c, config.Chat_Endpoint_Url__c)
+      : null;
+
     String resolvedEndpoint = String.isNotBlank(endpointUrl)
       ? endpointUrl
-      : (config != null ? config.Chat_Endpoint_Url__c : null);
+      : configuredStartSessionEndpoint;
 
     if (config == null) {
       throw new AuraHandledException('Missing Agentforce configuration');
@@ -563,6 +582,12 @@ public with sharing class AgentforceChatController {
     public String endpointUrl { get; set; }
 
     @AuraEnabled
+    public String startSessionEndpointUrl { get; set; }
+
+    @AuraEnabled
+    public String messagesEndpointUrl { get; set; }
+
+    @AuraEnabled
     public String botId { get; set; }
 
     @AuraEnabled
@@ -584,7 +609,8 @@ public with sharing class AgentforceChatController {
     public String password { get; set; }
 
     public AgentforceChatConfig(
-      String endpointUrl,
+      String startSessionEndpointUrl,
+      String messagesEndpointUrl,
       String botId,
       String authorizationHeaderValue,
       String tokenEndpointUrl,
@@ -593,7 +619,9 @@ public with sharing class AgentforceChatController {
       String username,
       String password
     ) {
-      this.endpointUrl = endpointUrl;
+      this.startSessionEndpointUrl = startSessionEndpointUrl;
+      this.endpointUrl = startSessionEndpointUrl;
+      this.messagesEndpointUrl = messagesEndpointUrl;
       this.botId = botId;
       this.authorizationHeaderValue = authorizationHeaderValue;
       this.tokenEndpointUrl = tokenEndpointUrl;

--- a/force-app/main/default/customMetadata/Agentforce_Config.Default.md-meta.xml
+++ b/force-app/main/default/customMetadata/Agentforce_Config.Default.md-meta.xml
@@ -11,6 +11,14 @@
         <value xsi:type="xsd:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">https://example.com/oauth/token</value>
     </values>
     <values>
+        <field>Start_Session_Endpoint_Url__c</field>
+        <value xsi:type="xsd:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">https://example.com/agentforce/sessions</value>
+    </values>
+    <values>
+        <field>Messages_Endpoint_Url__c</field>
+        <value xsi:type="xsd:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">https://example.com/agentforce</value>
+    </values>
+    <values>
         <field>Chat_Endpoint_Url__c</field>
         <value xsi:type="xsd:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">https://example.com/agentforce</value>
     </values>

--- a/force-app/main/default/lwc/agentforceChat/README.md
+++ b/force-app/main/default/lwc/agentforceChat/README.md
@@ -9,7 +9,9 @@ This Lightning Web Component renders an Agentforce-powered chat experience for E
 2. **Configure Agentforce connection and authentication**
    - Confirm that the OAuth and chat endpoints you plan to reach are added to Remote Site Settings (or otherwise permitted for callouts).
    - Update the `Agentforce_Config.Default` custom metadata record with your API settings:
-     - `Chat Endpoint Url` – the REST endpoint that accepts chat messages (for example, `https://example.com/agentforce`). This value is used as the component default and can still be overridden per component instance in Experience Builder.
+     - `Start Session Endpoint Url` – the REST endpoint that creates a new chat session (for example, `https://example.com/agentforce/sessions`). This value is used as the component default and can still be overridden per component instance in Experience Builder.
+     - `Messages Endpoint Url` – the REST endpoint (or base URL) that receives chat messages once a session exists. When the endpoint contains `{sessionId}`, the token is replaced automatically before the request is sent.
+     - `Chat Endpoint Url` – retained for backward compatibility. When populated, it is used as a fallback for the start-session and messages endpoints.
      - `Bot Id` – the Agentforce bot identifier to target.
      - `Endpoint Url` – the OAuth token endpoint that issues access tokens (for example, `https://example.com/oauth/token`).
      - `Consumer Key` and `Consumer Secret` – the client credentials for the OAuth connected app.

--- a/force-app/main/default/lwc/agentforceChat/__tests__/agentforceChat.test.js
+++ b/force-app/main/default/lwc/agentforceChat/__tests__/agentforceChat.test.js
@@ -74,7 +74,11 @@ describe('c-agentforce-chat', () => {
         element.botId = 'bot-123';
         document.body.appendChild(element);
 
-        getConfigAdapter.emit({ endpointUrl: 'https://default.example.com', botId: 'default-bot' });
+        getConfigAdapter.emit({
+            startSessionEndpointUrl: 'https://default.example.com/sessions',
+            messagesEndpointUrl: 'https://default.example.com',
+            botId: 'default-bot'
+        });
 
         mockStartSession.mockResolvedValue({
             sessionId: 'session-123',
@@ -123,7 +127,11 @@ describe('c-agentforce-chat', () => {
         element.botId = 'bot-123';
         document.body.appendChild(element);
 
-        getConfigAdapter.emit({ endpointUrl: 'https://default.example.com', botId: 'default-bot' });
+        getConfigAdapter.emit({
+            startSessionEndpointUrl: 'https://default.example.com/sessions',
+            messagesEndpointUrl: 'https://default.example.com',
+            botId: 'default-bot'
+        });
 
         mockStartSession.mockResolvedValue({
             sessionId: 'session-123',
@@ -149,5 +157,47 @@ describe('c-agentforce-chat', () => {
 
         const agentMessage = element.shadowRoot.querySelector('div[data-role="agent"] .message-body');
         expect(agentMessage.textContent).toBe('Agentforce request failed');
+    });
+
+    it('builds the messages endpoint from configured metadata when the session response omits URLs', async () => {
+        const element = createElement('c-agentforce-chat', {
+            is: AgentforceChat
+        });
+        element.botId = 'bot-123';
+        document.body.appendChild(element);
+
+        getConfigAdapter.emit({
+            startSessionEndpointUrl: 'https://example.com/agentforce/sessions',
+            messagesEndpointUrl: 'https://example.com/agentforce',
+            botId: 'bot-123'
+        });
+
+        mockStartSession.mockResolvedValue({
+            sessionId: 'session-789'
+        });
+        mockSendMessage.mockResolvedValue({ message: 'Reply' });
+
+        const textarea = element.shadowRoot.querySelector('lightning-textarea');
+        textarea.value = 'Hi there';
+        textarea.dispatchEvent(new CustomEvent('change'));
+
+        const button = element.shadowRoot.querySelector('lightning-button');
+        button.click();
+
+        await flushPromises();
+        await flushPromises();
+
+        expect(mockStartSession).toHaveBeenCalledWith(
+            expect.objectContaining({
+                endpointUrl: 'https://example.com/agentforce/sessions'
+            })
+        );
+
+        expect(mockSendMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                endpointUrl: 'https://example.com/agentforce/sessions/session-789/messages',
+                sessionId: 'session-789'
+            })
+        );
     });
 });

--- a/force-app/main/default/lwc/agentforceChat/agentforceChat.js
+++ b/force-app/main/default/lwc/agentforceChat/agentforceChat.js
@@ -18,16 +18,35 @@ const STATUS = {
 };
 
 export default class AgentforceChat extends LightningElement {
-    _endpointUrl;
+    _startSessionEndpointUrl;
+    _messagesEndpointUrl;
     _botId;
 
     @api
+    get startSessionEndpointUrl() {
+        return this._startSessionEndpointUrl;
+    }
+
+    set startSessionEndpointUrl(value) {
+        this._startSessionEndpointUrl = value;
+    }
+
+    @api
     get endpointUrl() {
-        return this._endpointUrl;
+        return this.startSessionEndpointUrl;
     }
 
     set endpointUrl(value) {
-        this._endpointUrl = value;
+        this.startSessionEndpointUrl = value;
+    }
+
+    @api
+    get messagesEndpointUrl() {
+        return this._messagesEndpointUrl;
+    }
+
+    set messagesEndpointUrl(value) {
+        this._messagesEndpointUrl = value;
     }
 
     @api
@@ -78,11 +97,7 @@ export default class AgentforceChat extends LightningElement {
     }
 
     get isSendDisabled() {
-        return !this.draftMessage || this.isLoading || !this.resolvedEndpoint;
-    }
-
-    get resolvedEndpoint() {
-        return this.endpointUrl || (this.wiredConfig?.data && this.wiredConfig.data.endpointUrl);
+        return !this.draftMessage || this.isLoading || !this.resolvedStartSessionEndpoint;
     }
 
     get resolvedBotId() {
@@ -97,12 +112,23 @@ export default class AgentforceChat extends LightningElement {
     }
 
     get resolvedStartSessionEndpoint() {
-        return this.resolvedEndpoint;
+        return (
+            this.startSessionEndpointUrl ||
+            (this.wiredConfig?.data &&
+                (this.wiredConfig.data.startSessionEndpointUrl || this.wiredConfig.data.endpointUrl))
+        );
+    }
+
+    get resolvedMessagesEndpointBase() {
+        return this.messagesEndpointUrl || (this.wiredConfig?.data && this.wiredConfig.data.messagesEndpointUrl);
     }
 
     applyConfig(data) {
-        if (!this.endpointUrl) {
-            this._endpointUrl = data.endpointUrl;
+        if (!this.startSessionEndpointUrl) {
+            this._startSessionEndpointUrl = data.startSessionEndpointUrl || data.endpointUrl;
+        }
+        if (!this.messagesEndpointUrl && data.messagesEndpointUrl) {
+            this._messagesEndpointUrl = data.messagesEndpointUrl;
         }
         if (!this.botId) {
             this._botId = data.botId;
@@ -184,13 +210,13 @@ export default class AgentforceChat extends LightningElement {
     }
 
     async initializeSession() {
-        const endpoint = this.resolvedStartSessionEndpoint;
-        if (!endpoint) {
+        const startSessionEndpoint = this.resolvedStartSessionEndpoint;
+        if (!startSessionEndpoint) {
             throw new Error('Missing Agentforce configuration');
         }
 
         const payload = this.buildStartSessionPayload();
-        const result = await startSession({ endpointUrl: endpoint, payload });
+        const result = await startSession({ endpointUrl: startSessionEndpoint, payload });
 
         const sessionId = this.extractSessionId(result);
         if (!sessionId) {
@@ -199,7 +225,7 @@ export default class AgentforceChat extends LightningElement {
 
         this.sessionId = sessionId;
         this.sessionKey = result?.externalSessionKey || payload.externalSessionKey;
-        this.messagesEndpoint = this.resolveMessagesEndpoint(result, sessionId, endpoint);
+        this.messagesEndpoint = this.resolveMessagesEndpoint(result, sessionId, startSessionEndpoint);
     }
 
     buildStartSessionPayload() {
@@ -285,12 +311,18 @@ export default class AgentforceChat extends LightningElement {
             }
         }
 
-        return this.buildMessagesEndpointFromBase(startEndpoint, sessionId);
+        const configuredBase = this.resolvedMessagesEndpointBase;
+        const fallbackBase = configuredBase || startEndpoint;
+        return this.buildMessagesEndpointFromBase(fallbackBase, sessionId);
     }
 
     buildMessagesEndpointFromBase(baseEndpoint, sessionId) {
         if (!baseEndpoint || !sessionId) {
             return undefined;
+        }
+
+        if (baseEndpoint.includes('{sessionId}')) {
+            return baseEndpoint.replace('{sessionId}', encodeURIComponent(sessionId));
         }
 
         let normalized = baseEndpoint.replace(/\/+$/, '');

--- a/force-app/main/default/lwc/agentforceChat/agentforceChat.js-meta.xml
+++ b/force-app/main/default/lwc/agentforceChat/agentforceChat.js-meta.xml
@@ -12,7 +12,8 @@
     </targets>
     <targetConfigs>
         <targetConfig targets="lightning__AppPage,lightning__RecordPage,lightning__HomePage,lightningCommunity__Page,lightningCommunity__Default">
-            <property name="endpointUrl" type="String" label="Agentforce Endpoint URL" description="REST endpoint that will receive chat messages." />
+            <property name="endpointUrl" type="String" label="Start Session Endpoint URL" description="REST endpoint used to start a new Agentforce chat session." />
+            <property name="messagesEndpointUrl" type="String" label="Messages Endpoint URL" description="REST endpoint (or base URL) used to post chat messages after a session is created. When omitted, the component derives this value from the start session endpoint." />
             <property name="botId" type="String" label="Bot ID" description="Identifier for the Agentforce bot to contact." />
         </targetConfig>
     </targetConfigs>

--- a/force-app/main/default/objects/Agentforce_Config__mdt/fields/Messages_Endpoint_Url__c.field-meta.xml
+++ b/force-app/main/default/objects/Agentforce_Config__mdt/fields/Messages_Endpoint_Url__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Messages_Endpoint_Url__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Messages Endpoint Url</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Agentforce_Config__mdt/fields/Start_Session_Endpoint_Url__c.field-meta.xml
+++ b/force-app/main/default/objects/Agentforce_Config__mdt/fields/Start_Session_Endpoint_Url__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Start_Session_Endpoint_Url__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>Start Session Endpoint Url</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
## Summary
- add dedicated custom metadata fields for the Agentforce start-session and message endpoints
- update the Apex controller and Lightning Web Component to honor the separate endpoints with backward-compatible fallbacks and tests
- document the configuration updates for Experience Builder admins

## Testing
- npm test agentforceChat *(fails: sfdx-lwc-jest not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ebac0dcb04832cb2ea133b592211f3