### PR TITLE
Update Agentforce chat send message payload

### DIFF
--- a/force-app/main/default/classes/AgentforceChatController.cls
+++ b/force-app/main/default/classes/AgentforceChatController.cls
@@ -43,7 +43,10 @@ public with sharing class AgentforceChatController {
     );
 
     String configuredMessagesEndpoint = config != null
-      ? preferString(config.Messages_Endpoint_Url__c, config.Chat_Endpoint_Url__c)
+      ? preferString(
+          config.Messages_Endpoint_Url__c,
+          config.Chat_Endpoint_Url__c
+        )
       : null;
 
     String resolvedEndpoint = String.isNotBlank(endpointUrl)
@@ -82,7 +85,10 @@ public with sharing class AgentforceChatController {
       consumerSecret
     );
 
-    String messagesEndpoint = applySessionPlaceholder(resolvedEndpoint, sessionId);
+    String messagesEndpoint = applySessionPlaceholder(
+      resolvedEndpoint,
+      sessionId
+    );
     if (String.isNotBlank(messagesEndpoint)) {
       Boolean hasSessionSegment = messagesEndpoint.contains('/sessions/');
       Boolean endsWithMessages = messagesEndpoint.endsWith('/messages');
@@ -107,13 +113,14 @@ public with sharing class AgentforceChatController {
       );
     }
 
+    Map<String, Object> messagePayload = new Map<String, Object>{
+      'sequenceId' => DateTime.now().getTime(),
+      'type' => 'Text',
+      'text' => message != null ? message : ''
+    };
     Map<String, Object> payload = new Map<String, Object>{
-      'botId' => resolvedBotId,
-      'message' => message,
-      'sessionId' => sessionId,
-      'transcript' => transcript != null
-        ? transcript
-        : new List<AgentforceChatTranscriptEntry>()
+      'message' => messagePayload,
+      'variables' => new List<Object>()
     };
     request.setBody(JSON.serialize(payload));
 
@@ -154,7 +161,10 @@ public with sharing class AgentforceChatController {
     );
 
     String configuredStartSessionEndpoint = config != null
-      ? preferString(config.Start_Session_Endpoint_Url__c, config.Chat_Endpoint_Url__c)
+      ? preferString(
+          config.Start_Session_Endpoint_Url__c,
+          config.Chat_Endpoint_Url__c
+        )
       : null;
 
     String resolvedEndpoint = String.isNotBlank(endpointUrl)
@@ -208,8 +218,9 @@ public with sharing class AgentforceChatController {
       : new Map<String, Object>();
     applyDefaultStartSessionPayload(payloadToSend);
 
-    String sessionKeyFromPayload = payloadToSend.containsKey('externalSessionKey') &&
-      payloadToSend.get('externalSessionKey') instanceof String
+    String sessionKeyFromPayload = payloadToSend.containsKey(
+        'externalSessionKey'
+      ) && payloadToSend.get('externalSessionKey') instanceof String
       ? (String) payloadToSend.get('externalSessionKey')
       : null;
 
@@ -359,7 +370,10 @@ public with sharing class AgentforceChatController {
     }
 
     Object existingSessionKey = payload.get('externalSessionKey');
-    if (!(existingSessionKey instanceof String) || String.isBlank((String) existingSessionKey)) {
+    if (
+      !(existingSessionKey instanceof String) ||
+      String.isBlank((String) existingSessionKey)
+    ) {
       payload.put('externalSessionKey', generateExternalSessionKey());
     }
 
@@ -368,7 +382,9 @@ public with sharing class AgentforceChatController {
       payload.containsKey('instanceConfig') &&
       payload.get('instanceConfig') instanceof Map<String, Object>
     ) {
-      instanceConfig.putAll((Map<String, Object>) payload.get('instanceConfig'));
+      instanceConfig.putAll(
+        (Map<String, Object>) payload.get('instanceConfig')
+      );
     }
     if (
       !instanceConfig.containsKey('endpoint') ||
@@ -396,7 +412,8 @@ public with sharing class AgentforceChatController {
     }
 
     Boolean hasVariables =
-      payload.containsKey('variables') && payload.get('variables') instanceof List<Object> &&
+      payload.containsKey('variables') &&
+      payload.get('variables') instanceof List<Object> &&
       !((List<Object>) payload.get('variables')).isEmpty();
     if (!hasVariables) {
       List<Object> variables = new List<Object>();
@@ -426,7 +443,8 @@ public with sharing class AgentforceChatController {
 
     Object featureSupport = payload.get('featureSupport');
     if (
-      !(featureSupport instanceof String) || String.isBlank((String) featureSupport)
+      !(featureSupport instanceof String) ||
+      String.isBlank((String) featureSupport)
     ) {
       payload.put('featureSupport', 'Streaming');
     }
@@ -492,8 +510,7 @@ public with sharing class AgentforceChatController {
     }
 
     if (
-      String.isBlank(result.messagesUrl) &&
-      String.isNotBlank(result.sessionUrl)
+      String.isBlank(result.messagesUrl) && String.isNotBlank(result.sessionUrl)
     ) {
       String normalizedSessionUrl = result.sessionUrl.endsWith('/messages')
         ? result.sessionUrl
@@ -502,15 +519,17 @@ public with sharing class AgentforceChatController {
     }
 
     if (
-      String.isBlank(result.messagesUrl) &&
-      String.isNotBlank(result.sessionId)
+      String.isBlank(result.messagesUrl) && String.isNotBlank(result.sessionId)
     ) {
       String baseSessionsUrl = extractString(
         result.data,
         new List<String>{ 'baseSessionsUrl', 'sessionsUrl', 'endpoint' }
       );
       if (String.isNotBlank(baseSessionsUrl)) {
-        result.messagesUrl = buildMessagesUrl(baseSessionsUrl, result.sessionId);
+        result.messagesUrl = buildMessagesUrl(
+          baseSessionsUrl,
+          result.sessionId
+        );
       }
     }
   }
@@ -534,9 +553,9 @@ public with sharing class AgentforceChatController {
     }
 
     return normalizedBase +
-    '/' +
-    EncodingUtil.urlEncode(sessionId, 'UTF-8') +
-    '/messages';
+      '/' +
+      EncodingUtil.urlEncode(sessionId, 'UTF-8') +
+      '/messages';
   }
 
   private static String extractString(


### PR DESCRIPTION
## Summary
- update the Agentforce chat controller so sendMessage posts a payload containing message metadata and variables in the required shape

## Testing
- npm run test:unit *(fails: existing Jest environment issues about setImmediate and out-of-scope mock variables)*

------
https://chatgpt.com/codex/tasks/task_e_68ec8f26733c832cb0455c6f35677dc4