### PR TITLE
feat: open agentforce chat from purchase history

### DIFF
--- a/force-app/main/default/lwc/agentforceChat/__tests__/agentforceChat.test.js
+++ b/force-app/main/default/lwc/agentforceChat/__tests__/agentforceChat.test.js
@@ -270,4 +270,49 @@ describe('c-agentforce-chat', () => {
             })
         );
     });
+
+    it('allows programmatic sends through the public sendMessage API', async () => {
+        const element = createElement('c-agentforce-chat', {
+            is: AgentforceChat
+        });
+        element.endpointUrl = 'https://example.com/api';
+        element.botId = 'bot-456';
+        document.body.appendChild(element);
+
+        getConfigAdapter.emit({
+            startSessionEndpointUrl: 'https://default.example.com/sessions',
+            messagesEndpointUrl: 'https://default.example.com',
+            botId: 'default-bot'
+        });
+
+        mockStartSession.mockResolvedValue({
+            sessionId: 'session-999',
+            messagesUrl: 'https://example.com/api/sessions/session-999/messages'
+        });
+
+        mockSendMessage.mockResolvedValue({
+            messages: [
+                {
+                    type: 'Inform',
+                    message: 'Acknowledged'
+                }
+            ]
+        });
+
+        await flushPromises();
+
+        await element.sendMessage('Order 42');
+
+        expect(mockStartSession).toHaveBeenCalledTimes(1);
+        expect(mockSendMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: 'Order 42',
+                sessionId: 'session-999',
+                endpointUrl: 'https://example.com/api/sessions/session-999/messages'
+            })
+        );
+
+        const agentMessage = element.shadowRoot.querySelector('div[data-role="agent"] .message-body');
+        expect(agentMessage.textContent).toBe('Acknowledged');
+    });
 });

--- a/force-app/main/default/lwc/agentforceChat/agentforceChat.js
+++ b/force-app/main/default/lwc/agentforceChat/agentforceChat.js
@@ -1,7 +1,7 @@
 import { LightningElement, api, wire } from 'lwc';
 import getConfig from '@salesforce/apex/AgentforceChatController.getConfig';
 import startSession from '@salesforce/apex/AgentforceChatController.startSession';
-import sendMessage from '@salesforce/apex/AgentforceChatController.sendMessage';
+import sendAgentforceMessage from '@salesforce/apex/AgentforceChatController.sendMessage';
 import USER_ID from '@salesforce/user/Id';
 import USER_LOCALE from '@salesforce/i18n/locale';
 import USER_TIMEZONE from '@salesforce/i18n/timeZone';
@@ -140,36 +140,67 @@ export default class AgentforceChat extends LightningElement {
     }
 
     async handleSend() {
-        if (!this.draftMessage) {
+        const draft = this.draftMessage;
+        this.draftMessage = '';
+        await this.sendMessage(draft);
+    }
+
+    @api
+    async sendMessage(content) {
+        const normalizedContent = this.normalizeMessageContent(content);
+        if (!normalizedContent) {
             return;
         }
 
-        const userMessage = this.createMessage('user', this.draftMessage);
-        this.messages = [...this.messages, userMessage];
-        const draft = this.draftMessage;
-        this.draftMessage = '';
-        this.errorMessage = undefined;
-        this.isLoading = true;
+        this.appendUserMessage(normalizedContent);
 
         try {
-            const response = await this.sendMessageToAgentforce(draft);
-            const agentResponses = this.buildAgentResponses(response);
-            if (agentResponses.length === 0) {
-                const fallback = this.createMessage(
-                    'agent',
-                    'Agentforce response missing message.'
-                );
-                this.messages = [...this.messages, fallback];
-            } else {
-                this.messages = [...this.messages, ...agentResponses];
-            }
+            const response = await this.performAgentforceSend(normalizedContent);
+            this.appendAgentResponses(response);
         } catch (error) {
-            this.errorMessage = this.normalizeError(error);
-            const errorMessage = this.createMessage('agent', this.errorMessage, 'error');
-            this.messages = [...this.messages, errorMessage];
+            this.handleAgentforceError(error);
         } finally {
             this.isLoading = false;
         }
+    }
+
+    normalizeMessageContent(content) {
+        if (content === null || content === undefined) {
+            return '';
+        }
+
+        const value = String(content).trim();
+        return value;
+    }
+
+    appendUserMessage(content) {
+        const userMessage = this.createMessage('user', content);
+        this.messages = [...this.messages, userMessage];
+        this.errorMessage = undefined;
+        this.isLoading = true;
+    }
+
+    async performAgentforceSend(content) {
+        return this.sendMessageToAgentforce(content);
+    }
+
+    appendAgentResponses(response) {
+        const agentResponses = this.buildAgentResponses(response);
+        if (agentResponses.length === 0) {
+            const fallback = this.createMessage(
+                'agent',
+                'Agentforce response missing message.'
+            );
+            this.messages = [...this.messages, fallback];
+        } else {
+            this.messages = [...this.messages, ...agentResponses];
+        }
+    }
+
+    handleAgentforceError(error) {
+        this.errorMessage = this.normalizeError(error);
+        const errorMessage = this.createMessage('agent', this.errorMessage, 'error');
+        this.messages = [...this.messages, errorMessage];
     }
 
     async sendMessageToAgentforce(content) {
@@ -185,7 +216,7 @@ export default class AgentforceChat extends LightningElement {
             throw new Error('Missing Agentforce session endpoint');
         }
 
-        return sendMessage({
+        return sendAgentforceMessage({
             message: content,
             transcript: this.messages.map((message) => ({
                 role: message.role,

--- a/force-app/main/default/lwc/purchaseHistory/__tests__/purchaseHistory.test.js
+++ b/force-app/main/default/lwc/purchaseHistory/__tests__/purchaseHistory.test.js
@@ -2,6 +2,24 @@ import { createElement } from 'lwc';
 import { ShowToastEventName } from 'lightning/platformShowToastEvent';
 import PurchaseHistory from 'c/purchaseHistory';
 
+const sendAgentforceMessageMock = jest.fn().mockResolvedValue();
+
+jest.mock(
+    'c/agentforceChat',
+    () => {
+        const { LightningElement, api } = require('lwc');
+        return {
+            default: class AgentforceChatStub extends LightningElement {
+                @api
+                async sendMessage(message) {
+                    return sendAgentforceMessageMock(message);
+                }
+            }
+        };
+    },
+    { virtual: true }
+);
+
 jest.mock(
     '@salesforce/apex/PurchaseHistoryController.getPurchaseHistory',
     () => ({
@@ -26,6 +44,7 @@ describe('c-purchase-history', () => {
             document.body.removeChild(document.body.firstChild);
         }
         jest.clearAllMocks();
+        sendAgentforceMessageMock.mockClear();
     });
 
     it('launches the returns agent workspace when the button is clicked', async () => {
@@ -62,6 +81,7 @@ describe('c-purchase-history', () => {
         button.click();
 
         await Promise.resolve();
+        await Promise.resolve();
 
         expect(launchReturnsAgentUiMock).toHaveBeenCalledTimes(1);
         const launchArgs = launchReturnsAgentUiMock.mock.calls[0][0];
@@ -72,6 +92,10 @@ describe('c-purchase-history', () => {
             }
         });
         expect(handler).toHaveBeenCalled();
+        expect(sendAgentforceMessageMock).toHaveBeenCalledWith('00012345');
+
+        const container = element.shadowRoot.querySelector('.agentforce-chat-container');
+        expect(container.classList.contains('agentforce-chat-container--visible')).toBe(true);
     });
 
     it('shows an error toast when order context is missing', async () => {

--- a/force-app/main/default/lwc/purchaseHistory/purchaseHistory.css
+++ b/force-app/main/default/lwc/purchaseHistory/purchaseHistory.css
@@ -222,6 +222,65 @@
     transition: background-color 0.2s ease, box-shadow 0.2s ease;
 }
 
+.agentforce-chat__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.75rem 1rem;
+    background-color: #0b5cab;
+    color: #ffffff;
+}
+
+.agentforce-chat__title {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.agentforce-chat__close {
+    background: transparent;
+    border: none;
+    color: inherit;
+    font-size: 1.25rem;
+    cursor: pointer;
+    line-height: 1;
+    padding: 0.25rem;
+}
+
+.agentforce-chat__close:hover,
+.agentforce-chat__close:focus {
+    color: #d8ebff;
+}
+
+.agentforce-chat__body {
+    background-color: #ffffff;
+    padding: 0.5rem;
+}
+
+.agentforce-chat-container {
+    position: fixed;
+    bottom: 1.5rem;
+    right: 1.5rem;
+    width: min(400px, calc(100% - 3rem));
+    max-height: 80vh;
+    display: none;
+    flex-direction: column;
+    border-radius: 0.75rem;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+    overflow: hidden;
+    z-index: 1000;
+    background-color: #ffffff;
+}
+
+.agentforce-chat-container--visible {
+    display: flex;
+}
+
+.agentforce-chat-container lightning-card {
+    --slds-c-card-shadow: none;
+    --slds-c-card-border-radius: 0;
+}
+
 .item-action:hover,
 .item-action:focus {
     background-color: #f7fafa;

--- a/force-app/main/default/lwc/purchaseHistory/purchaseHistory.html
+++ b/force-app/main/default/lwc/purchaseHistory/purchaseHistory.html
@@ -114,4 +114,25 @@
             </template>
         </div>
     </lightning-card>
+    <section
+        class={agentforceChatContainerClass}
+        role="dialog"
+        aria-label="返品・交換サポートチャット"
+        aria-hidden={agentforceChatAriaHidden}
+    >
+        <header class="agentforce-chat__header">
+            <h2 class="agentforce-chat__title">返品・交換サポート</h2>
+            <button
+                type="button"
+                class="agentforce-chat__close"
+                onclick={handleAgentforceChatClose}
+                aria-label="返品・交換サポートを閉じる"
+            >
+                ×
+            </button>
+        </header>
+        <div class="agentforce-chat__body">
+            <c-agentforce-chat></c-agentforce-chat>
+        </div>
+    </section>
 </template>

--- a/force-app/main/default/lwc/purchaseHistory/purchaseHistory.js
+++ b/force-app/main/default/lwc/purchaseHistory/purchaseHistory.js
@@ -9,6 +9,7 @@ export default class PurchaseHistory extends LightningElement {
     error;
     isLoading = false;
     isLaunchingAgent = false;
+    isAgentforceChatVisible = false;
 
     connectedCallback() {
         this.loadPurchaseHistory();
@@ -16,6 +17,16 @@ export default class PurchaseHistory extends LightningElement {
 
     get hasData() {
         return this.orders && this.orders.length > 0;
+    }
+
+    get agentforceChatContainerClass() {
+        return `agentforce-chat-container${
+            this.isAgentforceChatVisible ? ' agentforce-chat-container--visible' : ''
+        }`;
+    }
+
+    get agentforceChatAriaHidden() {
+        return this.isAgentforceChatVisible ? 'false' : 'true';
     }
 
     get errorMessage() {
@@ -78,6 +89,8 @@ export default class PurchaseHistory extends LightningElement {
 
         this.isLaunchingAgent = true;
 
+        this.openAgentforceChat(orderNumber);
+
         try {
             await launchReturnsAgentUi({
                 context: { orderId, orderItemId }
@@ -101,6 +114,28 @@ export default class PurchaseHistory extends LightningElement {
         } finally {
             this.isLaunchingAgent = false;
         }
+    }
+
+    async openAgentforceChat(orderNumber) {
+        this.isAgentforceChatVisible = true;
+
+        if (!orderNumber) {
+            return;
+        }
+
+        try {
+            const chat = this.template.querySelector('c-agentforce-chat');
+            if (chat && typeof chat.sendMessage === 'function') {
+                await chat.sendMessage(orderNumber);
+            }
+        } catch (error) {
+            // eslint-disable-next-line no-console
+            console.error('Failed to send message to Agentforce chat', error);
+        }
+    }
+
+    handleAgentforceChatClose() {
+        this.isAgentforceChatVisible = false;
     }
 
     groupHistoryByOrder(historyItems) {


### PR DESCRIPTION
## Summary
- show the Agentforce chat overlay from purchase history and allow it to be dismissed
- send the current order number to the Agentforce chat when "返品・交換" is clicked
- expose a public sendMessage API on the chat component and cover the new flows with Jest tests

## Testing
- npm test *(fails: sfdx-lwc-jest is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ec9cf0682c832cbc05e4c4d668684d