### PR TITLE
Ensure Agentforce chat composer stays visible

### DIFF
--- a/force-app/main/default/lwc/agentforceChat/agentforceChat.css
+++ b/force-app/main/default/lwc/agentforceChat/agentforceChat.css
@@ -1,8 +1,30 @@
+:host {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+}
+
+lightning-card {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+}
+
+.chat {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+}
+
 .status {
     display: flex;
     align-items: center;
     gap: 0.5rem;
     margin-bottom: 0.75rem;
+    flex-shrink: 0;
 }
 
 .status-text {
@@ -11,8 +33,8 @@
 }
 
 .transcript {
-    min-height: 12rem;
-    max-height: 28rem;
+    flex: 1 1 12rem;
+    min-height: 0;
     overflow-y: auto;
     padding: 0.75rem;
     border: 1px solid var(--lwc-colorBorder, #dddbda);
@@ -62,6 +84,12 @@
 .composer {
     display: grid;
     gap: 0.75rem;
+    position: sticky;
+    bottom: 0;
+    padding: 0.75rem 0 0 0;
+    background: var(--lwc-colorBackgroundAlt, #ffffff);
+    border-top: 1px solid var(--lwc-colorBorder, #dddbda);
+    flex-shrink: 0;
 }
 
 .spin {

--- a/force-app/main/default/lwc/agentforceChat/agentforceChat.html
+++ b/force-app/main/default/lwc/agentforceChat/agentforceChat.html
@@ -1,45 +1,47 @@
 <template>
     <lightning-card title="Agentforce Chat" icon-name="custom:custom14">
-        <div class="status" data-id="status">
-            <lightning-icon if:true={isLoading} icon-name="utility:refresh" alternative-text="Loading" class="spin"></lightning-icon>
-            <lightning-icon if:true={hasError} icon-name="utility:error" alternative-text="Error" class="error"></lightning-icon>
-            <template if:true={statusMessage}>
-                <span class="status-text">{statusMessage}</span>
-            </template>
-        </div>
-        <div class="transcript" data-id="transcript">
-            <template if:true={messages.length}>
-                <template for:each={messages} for:item="message">
-                    <div key={message.id} class={message.cssClass} data-role={message.role}>
-                        <div class="message-metadata">
-                            <span class="role">{message.roleLabel}</span>
-                            <span class="timestamp">{message.formattedTimestamp}</span>
-                        </div>
-                        <div class="message-body">{message.content}</div>
-                    </div>
+        <div class="chat">
+            <div class="status" data-id="status">
+                <lightning-icon if:true={isLoading} icon-name="utility:refresh" alternative-text="Loading" class="spin"></lightning-icon>
+                <lightning-icon if:true={hasError} icon-name="utility:error" alternative-text="Error" class="error"></lightning-icon>
+                <template if:true={statusMessage}>
+                    <span class="status-text">{statusMessage}</span>
                 </template>
-            </template>
-            <template if:false={messages.length}>
-                <p class="placeholder">No messages yet. Say hello to start the conversation.</p>
-            </template>
-        </div>
-        <div class="composer" data-id="composer">
-            <lightning-textarea
-                value={draftMessage}
-                onchange={handleDraftChange}
-                placeholder="Type your message..."
-                data-id="composer-input"
-                label="Your message"
-                maxlength="4000"
-            ></lightning-textarea>
-            <lightning-button
-                variant="brand"
-                label="Send"
-                onclick={handleSend}
-                disabled={isSendDisabled}
-                class="composer-send"
-                data-id="composer-send"
-            ></lightning-button>
+            </div>
+            <div class="transcript" data-id="transcript">
+                <template if:true={messages.length}>
+                    <template for:each={messages} for:item="message">
+                        <div key={message.id} class={message.cssClass} data-role={message.role}>
+                            <div class="message-metadata">
+                                <span class="role">{message.roleLabel}</span>
+                                <span class="timestamp">{message.formattedTimestamp}</span>
+                            </div>
+                            <div class="message-body">{message.content}</div>
+                        </div>
+                    </template>
+                </template>
+                <template if:false={messages.length}>
+                    <p class="placeholder">No messages yet. Say hello to start the conversation.</p>
+                </template>
+            </div>
+            <div class="composer" data-id="composer">
+                <lightning-textarea
+                    value={draftMessage}
+                    onchange={handleDraftChange}
+                    placeholder="Type your message..."
+                    data-id="composer-input"
+                    label="Your message"
+                    maxlength="4000"
+                ></lightning-textarea>
+                <lightning-button
+                    variant="brand"
+                    label="Send"
+                    onclick={handleSend}
+                    disabled={isSendDisabled}
+                    class="composer-send"
+                    data-id="composer-send"
+                ></lightning-button>
+            </div>
         </div>
     </lightning-card>
 </template>

--- a/force-app/main/default/lwc/agentforceChat/agentforceChat.js
+++ b/force-app/main/default/lwc/agentforceChat/agentforceChat.js
@@ -59,6 +59,7 @@ export default class AgentforceChat extends LightningElement {
     }
 
     messages = [];
+    lastRenderedMessageCount = 0;
     draftMessage = '';
     isLoading = false;
     errorMessage;
@@ -79,6 +80,20 @@ export default class AgentforceChat extends LightningElement {
             this.errorMessage = 'Configuration error';
             // eslint-disable-next-line no-console
             console.error('AgentforceChat configuration error', error);
+        }
+    }
+
+    renderedCallback() {
+        if (this.messages.length !== this.lastRenderedMessageCount) {
+            this.lastRenderedMessageCount = this.messages.length;
+            this.scrollTranscriptToBottom();
+        }
+    }
+
+    scrollTranscriptToBottom() {
+        const transcript = this.template.querySelector('[data-id="transcript"]');
+        if (transcript) {
+            transcript.scrollTop = transcript.scrollHeight;
         }
     }
 


### PR DESCRIPTION
## Summary
- wrap the Agentforce chat content in a flex container so the transcript scrolls independently
- adjust chat styles to keep the composer fixed at the bottom and improve scrolling behavior
- auto-scroll the transcript to the most recent message after each render

## Testing
- Not run (Node.js tooling is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68eca9f45194832cb63990a1a56d0631