### PR TITLE
feat: refresh agentforce chat ui

### DIFF
--- a/force-app/main/default/lwc/agentforceChat/agentforceChat.css
+++ b/force-app/main/default/lwc/agentforceChat/agentforceChat.css
@@ -5,91 +5,242 @@
     min-height: 0;
 }
 
-lightning-card {
+.chat-window {
     display: flex;
     flex-direction: column;
     flex: 1;
     min-height: 0;
+    background: #ffffff;
+    border-radius: 1.25rem;
+    overflow: hidden;
+    box-shadow: 0 20px 45px rgba(12, 44, 132, 0.25);
 }
 
-.chat {
+.chat-window__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+    padding: 1.25rem 1.5rem;
+    background: linear-gradient(135deg, #1f7bf2 0%, #0b5cab 100%);
+    color: #ffffff;
+}
+
+.chat-window__brand {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.chat-window__avatar {
+    display: inline-flex;
+    width: 2.75rem;
+    height: 2.75rem;
+    align-items: center;
+    justify-content: center;
+    background: rgba(255, 255, 255, 0.2);
+    border-radius: 50%;
+    box-shadow: 0 8px 18px rgba(5, 24, 77, 0.25);
+}
+
+.chat-window__avatar-icon {
+    --sds-c-icon-color-foreground-default: #ffffff;
+}
+
+.chat-window__titles {
     display: flex;
     flex-direction: column;
-    flex: 1;
-    min-height: 0;
+    gap: 0.25rem;
+}
+
+.chat-window__eyebrow {
+    margin: 0;
+    font-size: 0.75rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    opacity: 0.85;
+}
+
+.chat-window__title {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 700;
+    line-height: 1.4;
 }
 
 .status {
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    margin-bottom: 0.75rem;
     flex-shrink: 0;
+    font-size: 0.75rem;
+    background: rgba(12, 62, 139, 0.35);
+    border-radius: 999px;
+    padding: 0.35rem 0.75rem;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25);
 }
 
 .status-text {
-    font-size: 0.875rem;
-    color: var(--lwc-colorTextLabel, #514f4d);
+    font-weight: 600;
+    color: #ffffff;
+}
+
+.chat-window__body {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
+    padding: 1.25rem 1.5rem 1.5rem;
+    background: linear-gradient(180deg, #eef3ff 0%, #ffffff 100%);
 }
 
 .transcript {
     flex: 1 1 12rem;
     min-height: 0;
     overflow-y: auto;
-    padding: 0.75rem;
-    border: 1px solid var(--lwc-colorBorder, #dddbda);
-    border-radius: var(--lwc-borderRadiusMedium, 0.25rem);
-    background: var(--lwc-colorBackgroundAlt, #ffffff);
+    padding: 1rem;
+    background: #f7f9ff;
+    border-radius: 1rem;
+    box-shadow: inset 0 0 0 1px rgba(124, 158, 247, 0.2);
     margin-bottom: 1rem;
 }
 
-.message-metadata {
-    font-size: 0.75rem;
-    color: var(--lwc-colorTextWeak, #706e6b);
+.message {
     display: flex;
-    justify-content: space-between;
-    margin-bottom: 0.25rem;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+    align-items: flex-end;
+}
+
+.message:last-child {
+    margin-bottom: 0;
+}
+
+.message.agent {
+    justify-content: flex-start;
+}
+
+.message.user {
+    justify-content: flex-end;
+}
+
+.message.error .message-body {
+    border: 1px solid var(--lwc-colorBorderError, #ea001e);
+    color: var(--lwc-colorTextError, #ea001e);
+}
+
+.message__avatar {
+    display: inline-flex;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #1f7bf2 0%, #0b5cab 100%);
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 10px 25px rgba(15, 59, 138, 0.25);
+}
+
+.message__avatar-icon {
+    --sds-c-icon-color-foreground-default: #ffffff;
+}
+
+.message__content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    max-width: 85%;
+}
+
+.message.agent .message__content {
+    align-items: flex-start;
+}
+
+.message.user .message__content {
+    align-items: flex-end;
 }
 
 .message-body {
     white-space: pre-wrap;
     word-break: break-word;
+    padding: 0.85rem 1rem;
+    border-radius: 1rem;
+    font-size: 0.95rem;
+    line-height: 1.5;
+    box-shadow: 0 8px 20px rgba(15, 59, 138, 0.08);
+    background: #ffffff;
+    color: #1f2d3d;
 }
 
-.message {
-    padding: 0.5rem 0.75rem;
-    margin-bottom: 0.75rem;
-    border-radius: var(--lwc-borderRadiusMedium, 0.25rem);
+.message.agent .message-body {
+    border-top-left-radius: 0.5rem;
 }
 
-.message.agent {
-    background: var(--lwc-colorBackgroundHighlight, #f3f2f2);
+.message.user .message-body {
+    background: linear-gradient(135deg, #0b5cab 0%, #2b98ff 100%);
+    color: #ffffff;
+    border-top-right-radius: 0.5rem;
+    box-shadow: 0 12px 25px rgba(11, 92, 171, 0.35);
 }
 
-.message.user {
-    background: var(--lwc-colorBackgroundToastSuccess, #e3fcef);
+.message-metadata {
+    font-size: 0.7rem;
+    color: #5b6a9a;
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
 }
 
-.message.error {
-    border: 1px solid var(--lwc-colorBorderError, #ea001e);
-    color: var(--lwc-colorTextError, #ea001e);
+.message.user .message-metadata {
+    justify-content: flex-end;
+    color: rgba(255, 255, 255, 0.75);
 }
 
 .placeholder {
-    color: var(--lwc-colorTextWeak, #706e6b);
+    color: #5b6a9a;
     text-align: center;
     margin: 2rem 0;
 }
 
 .composer {
-    display: grid;
+    display: flex;
     gap: 0.75rem;
-    position: sticky;
-    bottom: 0;
-    padding: 0.75rem 0 0 0;
-    background: var(--lwc-colorBackgroundAlt, #ffffff);
-    border-top: 1px solid var(--lwc-colorBorder, #dddbda);
-    flex-shrink: 0;
+    align-items: flex-end;
+    padding-top: 1rem;
+    border-top: 1px solid rgba(124, 158, 247, 0.35);
+}
+
+.composer lightning-textarea {
+    flex: 1 1 auto;
+    --slds-c-textarea-sizing-min-height: 3.5rem;
+    --slds-c-textarea-radius-border: 1.25rem;
+    --slds-c-textarea-color-border: transparent;
+    --slds-c-textarea-color-border-hover: transparent;
+    --slds-c-textarea-color-border-focus: transparent;
+    --slds-c-textarea-shadow: inset 0 0 0 1px rgba(124, 158, 247, 0.55);
+    --slds-c-textarea-shadow-focus: 0 0 0 3px rgba(31, 123, 242, 0.3);
+    --slds-c-textarea-color-background: #f7f9ff;
+    --slds-c-textarea-color-text: #1f2d3d;
+}
+
+.composer lightning-textarea textarea {
+    padding: 0.75rem 1rem;
+}
+
+.composer-send {
+    --slds-c-button-brand-color-background: #0b5cab;
+    --slds-c-button-brand-color-background-hover: #094b8d;
+    --slds-c-button-brand-color-border: transparent;
+    --slds-c-button-brand-color-border-hover: transparent;
+    --slds-c-button-radius-border: 999px;
+    --slds-c-button-brand-spacing-inline: 1.75rem;
+    --slds-c-button-brand-spacing-block: 0.75rem;
+    --slds-c-button-font-weight: 700;
+    --slds-c-button-brand-text-color: #ffffff;
+    box-shadow: 0 12px 25px rgba(11, 92, 171, 0.35);
+}
+
+.composer-send lightning-icon {
+    --sds-c-icon-color-foreground-default: #ffffff;
 }
 
 .spin {
@@ -106,5 +257,5 @@ lightning-card {
 }
 
 .error {
-    color: var(--lwc-colorTextError, #ea001e);
+    color: #ffd1d9;
 }

--- a/force-app/main/default/lwc/agentforceChat/agentforceChat.html
+++ b/force-app/main/default/lwc/agentforceChat/agentforceChat.html
@@ -1,6 +1,20 @@
 <template>
-    <lightning-card title="Agentforce Chat" icon-name="custom:custom14">
-        <div class="chat">
+    <section class="chat-window">
+        <header class="chat-window__header">
+            <div class="chat-window__brand">
+                <span class="chat-window__avatar" aria-hidden="true">
+                    <lightning-icon
+                        icon-name="utility:bot"
+                        alternative-text="Agentforce bot"
+                        size="small"
+                        class="chat-window__avatar-icon"
+                    ></lightning-icon>
+                </span>
+                <div class="chat-window__titles">
+                    <p class="chat-window__eyebrow">リゲルソフト サポート</p>
+                    <h2 class="chat-window__title">リゲルソフトの生成AIロボットが回答中！</h2>
+                </div>
+            </div>
             <div class="status" data-id="status">
                 <lightning-icon if:true={isLoading} icon-name="utility:refresh" alternative-text="Loading" class="spin"></lightning-icon>
                 <lightning-icon if:true={hasError} icon-name="utility:error" alternative-text="Error" class="error"></lightning-icon>
@@ -8,34 +22,51 @@
                     <span class="status-text">{statusMessage}</span>
                 </template>
             </div>
+        </header>
+        <div class="chat-window__body">
             <div class="transcript" data-id="transcript">
                 <template if:true={messages.length}>
                     <template for:each={messages} for:item="message">
                         <div key={message.id} class={message.cssClass} data-role={message.role}>
-                            <div class="message-metadata">
-                                <span class="role">{message.roleLabel}</span>
-                                <span class="timestamp">{message.formattedTimestamp}</span>
+                            <template if:true={message.isAgent}>
+                                <span class="message__avatar" aria-hidden="true">
+                                    <lightning-icon
+                                        icon-name="utility:bot"
+                                        alternative-text="Agentforce bot"
+                                        size="x-small"
+                                        class="message__avatar-icon"
+                                    ></lightning-icon>
+                                </span>
+                            </template>
+                            <div class="message__content">
+                                <div class="message-body">{message.content}</div>
+                                <div class="message-metadata">
+                                    <span class="role">{message.roleLabel}</span>
+                                    <span class="timestamp">{message.formattedTimestamp}</span>
+                                </div>
                             </div>
-                            <div class="message-body">{message.content}</div>
                         </div>
                     </template>
                 </template>
                 <template if:false={messages.length}>
-                    <p class="placeholder">No messages yet. Say hello to start the conversation.</p>
+                    <p class="placeholder">まだメッセージはありません。まずは挨拶してみましょう。</p>
                 </template>
             </div>
             <div class="composer" data-id="composer">
                 <lightning-textarea
                     value={draftMessage}
                     onchange={handleDraftChange}
-                    placeholder="Type your message..."
+                    placeholder="メッセージを入力してください..."
                     data-id="composer-input"
-                    label="Your message"
+                    label="メッセージ"
                     maxlength="4000"
                 ></lightning-textarea>
                 <lightning-button
                     variant="brand"
-                    label="Send"
+                    label="送信"
+                    title="送信"
+                    icon-name="utility:send"
+                    icon-position="right"
                     onclick={handleSend}
                     disabled={isSendDisabled}
                     class="composer-send"
@@ -43,5 +74,5 @@
                 ></lightning-button>
             </div>
         </div>
-    </lightning-card>
+    </section>
 </template>

--- a/force-app/main/default/lwc/agentforceChat/agentforceChat.js
+++ b/force-app/main/default/lwc/agentforceChat/agentforceChat.js
@@ -545,7 +545,8 @@ export default class AgentforceChat extends LightningElement {
                 minute: 'numeric',
                 hour12: true
             }).format(new Date(timestamp)),
-            cssClass: `message ${role}${variant ? ` ${variant}` : ''}`
+            cssClass: `message ${role}${variant ? ` ${variant}` : ''}`,
+            isAgent: role === 'agent'
         };
     }
 }


### PR DESCRIPTION
## Summary
- Rebuilt the Agentforce chat markup with a branded header, localized labels, agent avatar support, and a redesigned composer to align with the reference mockup.
- Applied new styling for the transcript, message bubbles, and send action to deliver the updated Agentforce Chat visual design.

## Testing
- npm test agentforceChat *(fails: `sfdx-lwc-jest` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ecacd1417c832cac89b9be731a10d1