### PR TITLE
refactor: surface chat status inside transcript

### DIFF
--- a/force-app/main/default/lwc/agentforceChat/README.md
+++ b/force-app/main/default/lwc/agentforceChat/README.md
@@ -27,7 +27,8 @@ This Lightning Web Component renders an Agentforce-powered chat experience for E
 
 - Messages sent from the composer are posted to the configured Agentforce REST endpoint along with the existing transcript. Before each chat callout, the controller performs the OAuth client credentials flow using the stored client ID and secret and passes the resulting bearer token to the chat service.
 - Agent responses are appended to the transcript when the API returns.
-- Errors are surfaced in the status banner and echoed into the transcript for quick diagnosis.
+- Status updates (sending state and errors) appear inline within the agent transcript so customers can track progress without a
+  separate header.
 
 ## Testing
 

--- a/force-app/main/default/lwc/agentforceChat/__tests__/agentforceChat.test.js
+++ b/force-app/main/default/lwc/agentforceChat/__tests__/agentforceChat.test.js
@@ -155,12 +155,14 @@ describe('c-agentforce-chat', () => {
         const button = element.shadowRoot.querySelector('lightning-button');
         button.click();
 
+        const statusBubble = element.shadowRoot.querySelector('.message.status .message-body');
+        expect(statusBubble).not.toBeNull();
+        expect(statusBubble.textContent).toBe('Sending message…');
+
         await flushPromises();
         await flushPromises();
 
-        const statusText = element.shadowRoot.querySelector('[data-id="status"] .status-text');
-        expect(statusText.textContent).toContain('Unable to send message');
-        expect(statusText.textContent).toContain('Agentforce request failed');
+        expect(element.shadowRoot.querySelector('.message.status')).toBeNull();
 
         const agentMessage = element.shadowRoot.querySelector('div[data-role="agent"] .message-body');
         expect(agentMessage.textContent).toBe('Agentforce request failed');

--- a/force-app/main/default/lwc/agentforceChat/agentforceChat.css
+++ b/force-app/main/default/lwc/agentforceChat/agentforceChat.css
@@ -5,106 +5,184 @@
     min-height: 0;
 }
 
-lightning-card {
+.chat-window {
     display: flex;
     flex-direction: column;
     flex: 1;
     min-height: 0;
+    background: #ffffff;
+    border-radius: 1.25rem;
+    overflow: hidden;
+    box-shadow: 0 20px 45px rgba(12, 44, 132, 0.25);
 }
 
-.chat {
+.chat-window__body {
     display: flex;
     flex-direction: column;
-    flex: 1;
+    flex: 1 1 auto;
     min-height: 0;
-}
-
-.status {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    margin-bottom: 0.75rem;
-    flex-shrink: 0;
-}
-
-.status-text {
-    font-size: 0.875rem;
-    color: var(--lwc-colorTextLabel, #514f4d);
+    padding: 1.5rem;
+    gap: 1.5rem;
+    background: #f4f7ff;
 }
 
 .transcript {
-    flex: 1 1 12rem;
+    flex: 1 1 20rem;
     min-height: 0;
     overflow-y: auto;
-    padding: 0.75rem;
-    border: 1px solid var(--lwc-colorBorder, #dddbda);
-    border-radius: var(--lwc-borderRadiusMedium, 0.25rem);
-    background: var(--lwc-colorBackgroundAlt, #ffffff);
-    margin-bottom: 1rem;
+    padding: 1rem 1.25rem;
+    background: #f7f9ff;
+    border-radius: 1rem;
+    box-shadow: inset 0 0 0 1px rgba(124, 158, 247, 0.2);
+    margin-bottom: 0.5rem;
 }
 
-.message-metadata {
-    font-size: 0.75rem;
-    color: var(--lwc-colorTextWeak, #706e6b);
+.message {
     display: flex;
-    justify-content: space-between;
-    margin-bottom: 0.25rem;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+    align-items: flex-end;
+}
+
+.message:last-child {
+    margin-bottom: 0;
+}
+
+.message.agent {
+    justify-content: flex-start;
+}
+
+.message.user {
+    justify-content: flex-end;
+}
+
+.message.error .message-body {
+    border: 1px solid var(--lwc-colorBorderError, #ea001e);
+    color: var(--lwc-colorTextError, #ea001e);
+}
+
+.message.status .message-body {
+    background: #ecf2ff;
+    color: #0b5cab;
+    box-shadow: none;
+    border: 1px solid rgba(31, 123, 242, 0.25);
+}
+
+.message.status .message-metadata {
+    display: none;
+}
+
+.message__avatar {
+    display: inline-flex;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #1f7bf2 0%, #0b5cab 100%);
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 10px 25px rgba(15, 59, 138, 0.25);
+}
+
+.message__avatar-icon {
+    --sds-c-icon-color-foreground-default: #ffffff;
+}
+
+.message__content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    max-width: 85%;
+}
+
+.message.agent .message__content {
+    align-items: flex-start;
+}
+
+.message.user .message__content {
+    align-items: flex-end;
 }
 
 .message-body {
     white-space: pre-wrap;
     word-break: break-word;
+    padding: 0.85rem 1rem;
+    border-radius: 1rem;
+    font-size: 0.95rem;
+    line-height: 1.5;
+    box-shadow: 0 8px 20px rgba(15, 59, 138, 0.08);
+    background: #ffffff;
+    color: #1f2d3d;
 }
 
-.message {
-    padding: 0.5rem 0.75rem;
-    margin-bottom: 0.75rem;
-    border-radius: var(--lwc-borderRadiusMedium, 0.25rem);
+.message.agent .message-body {
+    border-top-left-radius: 0.5rem;
 }
 
-.message.agent {
-    background: var(--lwc-colorBackgroundHighlight, #f3f2f2);
+.message.user .message-body {
+    background: linear-gradient(135deg, #0b5cab 0%, #2b98ff 100%);
+    color: #ffffff;
+    border-top-right-radius: 0.5rem;
+    box-shadow: 0 12px 25px rgba(11, 92, 171, 0.35);
 }
 
-.message.user {
-    background: var(--lwc-colorBackgroundToastSuccess, #e3fcef);
+.message-metadata {
+    font-size: 0.7rem;
+    color: #5b6a9a;
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
 }
 
-.message.error {
-    border: 1px solid var(--lwc-colorBorderError, #ea001e);
-    color: var(--lwc-colorTextError, #ea001e);
+.message.user .message-metadata {
+    justify-content: flex-end;
+    color: rgba(255, 255, 255, 0.75);
 }
 
 .placeholder {
-    color: var(--lwc-colorTextWeak, #706e6b);
+    color: #5b6a9a;
     text-align: center;
     margin: 2rem 0;
 }
 
 .composer {
-    display: grid;
+    display: flex;
     gap: 0.75rem;
-    position: sticky;
-    bottom: 0;
-    padding: 0.75rem 0 0 0;
-    background: var(--lwc-colorBackgroundAlt, #ffffff);
-    border-top: 1px solid var(--lwc-colorBorder, #dddbda);
-    flex-shrink: 0;
+    align-items: flex-end;
+    padding-top: 1rem;
+    border-top: 1px solid rgba(124, 158, 247, 0.35);
 }
 
-.spin {
-    animation: spin 1s linear infinite;
+.composer lightning-textarea {
+    flex: 1 1 auto;
+    --slds-c-textarea-sizing-min-height: 3.5rem;
+    --slds-c-textarea-radius-border: 1.25rem;
+    --slds-c-textarea-color-border: transparent;
+    --slds-c-textarea-color-border-hover: transparent;
+    --slds-c-textarea-color-border-focus: transparent;
+    --slds-c-textarea-shadow: inset 0 0 0 1px rgba(124, 158, 247, 0.55);
+    --slds-c-textarea-shadow-focus: 0 0 0 3px rgba(31, 123, 242, 0.3);
+    --slds-c-textarea-color-background: #f7f9ff;
+    --slds-c-textarea-color-text: #1f2d3d;
 }
 
-@keyframes spin {
-    0% {
-        transform: rotate(0deg);
-    }
-    100% {
-        transform: rotate(360deg);
-    }
+.composer lightning-textarea textarea {
+    padding: 0.75rem 1rem;
 }
 
-.error {
-    color: var(--lwc-colorTextError, #ea001e);
+.composer-send {
+    --slds-c-button-brand-color-background: #0b5cab;
+    --slds-c-button-brand-color-background-hover: #094b8d;
+    --slds-c-button-brand-color-border: transparent;
+    --slds-c-button-brand-color-border-hover: transparent;
+    --slds-c-button-radius-border: 999px;
+    --slds-c-button-brand-spacing-inline: 1.75rem;
+    --slds-c-button-brand-spacing-block: 0.75rem;
+    --slds-c-button-font-weight: 700;
+    --slds-c-button-brand-text-color: #ffffff;
+    box-shadow: 0 12px 25px rgba(11, 92, 171, 0.35);
 }
+
+.composer-send lightning-icon {
+    --sds-c-icon-color-foreground-default: #ffffff;
+}
+

--- a/force-app/main/default/lwc/agentforceChat/agentforceChat.html
+++ b/force-app/main/default/lwc/agentforceChat/agentforceChat.html
@@ -1,41 +1,49 @@
 <template>
-    <lightning-card title="Agentforce Chat" icon-name="custom:custom14">
-        <div class="chat">
-            <div class="status" data-id="status">
-                <lightning-icon if:true={isLoading} icon-name="utility:refresh" alternative-text="Loading" class="spin"></lightning-icon>
-                <lightning-icon if:true={hasError} icon-name="utility:error" alternative-text="Error" class="error"></lightning-icon>
-                <template if:true={statusMessage}>
-                    <span class="status-text">{statusMessage}</span>
-                </template>
-            </div>
+    <section class="chat-window">
+        <div class="chat-window__body">
             <div class="transcript" data-id="transcript">
                 <template if:true={messages.length}>
                     <template for:each={messages} for:item="message">
                         <div key={message.id} class={message.cssClass} data-role={message.role}>
-                            <div class="message-metadata">
-                                <span class="role">{message.roleLabel}</span>
-                                <span class="timestamp">{message.formattedTimestamp}</span>
+                            <template if:true={message.isAgent}>
+                                <span class="message__avatar" aria-hidden="true">
+                                    <lightning-icon
+                                        icon-name="standard:bot"
+                                        alternative-text="Agentforce bot"
+                                        size="x-small"
+                                        class="message__avatar-icon"
+                                    ></lightning-icon>
+                                </span>
+                            </template>
+                            <div class="message__content">
+                                <div class="message-body">{message.content}</div>
+                                <div class="message-metadata">
+                                    <span class="role">{message.roleLabel}</span>
+                                    <span class="timestamp">{message.formattedTimestamp}</span>
+                                </div>
                             </div>
-                            <div class="message-body">{message.content}</div>
                         </div>
                     </template>
                 </template>
                 <template if:false={messages.length}>
-                    <p class="placeholder">No messages yet. Say hello to start the conversation.</p>
+                    <p class="placeholder">まだメッセージはありません。まずは挨拶してみましょう。</p>
                 </template>
             </div>
             <div class="composer" data-id="composer">
                 <lightning-textarea
                     value={draftMessage}
                     onchange={handleDraftChange}
-                    placeholder="Type your message..."
+                    placeholder="メッセージを入力してください..."
                     data-id="composer-input"
-                    label="Your message"
+                    label="メッセージ"
                     maxlength="4000"
                 ></lightning-textarea>
                 <lightning-button
                     variant="brand"
-                    label="Send"
+                    label="送信"
+                    title="送信"
+                    icon-name="utility:send"
+                    icon-position="right"
                     onclick={handleSend}
                     disabled={isSendDisabled}
                     class="composer-send"
@@ -43,5 +51,5 @@
                 ></lightning-button>
             </div>
         </div>
-    </lightning-card>
+    </section>
 </template>

--- a/force-app/main/default/lwc/agentforceChat/agentforceChat.js
+++ b/force-app/main/default/lwc/agentforceChat/agentforceChat.js
@@ -12,9 +12,7 @@ const ROLE_LABELS = {
 };
 
 const STATUS = {
-    READY: 'Ready to chat',
-    SENDING: 'Sending message…',
-    ERROR: 'Unable to send message'
+    SENDING: 'Sending message…'
 };
 
 export default class AgentforceChat extends LightningElement {
@@ -63,6 +61,7 @@ export default class AgentforceChat extends LightningElement {
     draftMessage = '';
     isLoading = false;
     errorMessage;
+    statusMessageId;
     sessionId;
     sessionKey;
     messagesEndpoint;
@@ -95,20 +94,6 @@ export default class AgentforceChat extends LightningElement {
         if (transcript) {
             transcript.scrollTop = transcript.scrollHeight;
         }
-    }
-
-    get statusMessage() {
-        if (this.errorMessage) {
-            return `${STATUS.ERROR}: ${this.errorMessage}`;
-        }
-        if (this.isLoading) {
-            return STATUS.SENDING;
-        }
-        return STATUS.READY;
-    }
-
-    get hasError() {
-        return Boolean(this.errorMessage);
     }
 
     get isSendDisabled() {
@@ -168,6 +153,7 @@ export default class AgentforceChat extends LightningElement {
         }
 
         this.appendUserMessage(normalizedContent);
+        this.showStatusMessage(STATUS.SENDING);
 
         try {
             const response = await this.performAgentforceSend(normalizedContent);
@@ -193,6 +179,7 @@ export default class AgentforceChat extends LightningElement {
         this.messages = [...this.messages, userMessage];
         this.errorMessage = undefined;
         this.isLoading = true;
+        this.removeStatusMessage();
     }
 
     async performAgentforceSend(content) {
@@ -202,20 +189,21 @@ export default class AgentforceChat extends LightningElement {
     appendAgentResponses(response) {
         const agentResponses = this.buildAgentResponses(response);
         if (agentResponses.length === 0) {
-            const fallback = this.createMessage(
-                'agent',
-                'Agentforce response missing message.'
-            );
-            this.messages = [...this.messages, fallback];
-        } else {
-            this.messages = [...this.messages, ...agentResponses];
+            this.updateStatusMessage('Agentforce response missing message.', 'status', true);
+            return;
+        }
+
+        const [firstResponse, ...additionalResponses] = agentResponses;
+        this.replaceStatusMessageWith(firstResponse);
+
+        if (additionalResponses.length) {
+            this.messages = [...this.messages, ...additionalResponses];
         }
     }
 
     handleAgentforceError(error) {
         this.errorMessage = this.normalizeError(error);
-        const errorMessage = this.createMessage('agent', this.errorMessage, 'error');
-        this.messages = [...this.messages, errorMessage];
+        this.updateStatusMessage(this.errorMessage, 'error', true);
     }
 
     async sendMessageToAgentforce(content) {
@@ -545,7 +533,59 @@ export default class AgentforceChat extends LightningElement {
                 minute: 'numeric',
                 hour12: true
             }).format(new Date(timestamp)),
-            cssClass: `message ${role}${variant ? ` ${variant}` : ''}`
+            cssClass: `message ${role}${variant ? ` ${variant}` : ''}`,
+            isAgent: role === 'agent'
         };
+    }
+
+    showStatusMessage(content, variant = 'status') {
+        const statusMessage = this.createMessage('agent', content, variant);
+        this.statusMessageId = statusMessage.id;
+        this.messages = [...this.messages, statusMessage];
+    }
+
+    updateStatusMessage(content, variant = 'status', finalize = false) {
+        if (!this.statusMessageId) {
+            if (finalize) {
+                this.messages = [...this.messages, this.createMessage('agent', content, variant)];
+                return;
+            }
+            this.showStatusMessage(content, variant);
+            return;
+        }
+
+        const statusId = this.statusMessageId;
+        const replacement = this.createMessage('agent', content, variant);
+
+        this.messages = this.messages.map((message) =>
+            message.id === statusId ? { ...replacement, id: statusId } : message
+        );
+
+        if (finalize) {
+            this.statusMessageId = undefined;
+        }
+    }
+
+    replaceStatusMessageWith(message) {
+        if (!this.statusMessageId) {
+            this.messages = [...this.messages, message];
+            return;
+        }
+
+        const statusId = this.statusMessageId;
+        this.messages = this.messages.map((existing) =>
+            existing.id === statusId ? { ...message, id: statusId } : existing
+        );
+        this.statusMessageId = undefined;
+    }
+
+    removeStatusMessage() {
+        if (!this.statusMessageId) {
+            return;
+        }
+
+        const statusId = this.statusMessageId;
+        this.messages = this.messages.filter((message) => message.id !== statusId);
+        this.statusMessageId = undefined;
     }
 }


### PR DESCRIPTION
## Summary
- remove the chat window header banner and render status updates as agent messages inside the transcript
- add styling and lifecycle helpers so status bubbles swap to real responses or errors when server data arrives
- update the Jest spec and README to reflect the inline status behaviour

## Testing
- npm test agentforceChat *(fails: `sfdx-lwc-jest: not found` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ecacd1417c832cac89b9be731a10d1