### PR TITLE
feat: add return eligibility evaluation service

### DIFF
--- a/force-app/main/default/classes/ReturnEligibilityService.cls
+++ b/force-app/main/default/classes/ReturnEligibilityService.cls
@@ -1,0 +1,514 @@
+public with sharing class ReturnEligibilityService {
+    public class EvaluationInput {
+        @InvocableVariable(required=true)
+        public String productIdentifier;
+
+        @InvocableVariable
+        public String returnReason;
+    }
+
+    @AuraEnabled
+    public class EvaluationResult {
+        @AuraEnabled
+        @InvocableVariable
+        public Boolean productFound;
+
+        @AuraEnabled
+        @InvocableVariable
+        public Boolean requiresReason;
+
+        @AuraEnabled
+        @InvocableVariable
+        public Boolean isReturnable;
+
+        @AuraEnabled
+        @InvocableVariable
+        public Boolean reasonAccepted;
+
+        @AuraEnabled
+        @InvocableVariable
+        public String reasonCategory;
+
+        @AuraEnabled
+        @InvocableVariable
+        public String policyName;
+
+        @AuraEnabled
+        @InvocableVariable
+        public String policyType;
+
+        @AuraEnabled
+        @InvocableVariable
+        public String policyDescription;
+
+        @AuraEnabled
+        @InvocableVariable
+        public String primaryMessage;
+
+        @AuraEnabled
+        @InvocableVariable
+        public String secondaryMessage;
+
+        @AuraEnabled
+        @InvocableVariable
+        public String exchangeMessage;
+
+        @AuraEnabled
+        public List<ProductSuggestion> exchangeOptions;
+
+        @AuraEnabled
+        public List<ProductSuggestion> alternativeProducts;
+
+        @AuraEnabled
+        @InvocableVariable
+        public String alternativeMessage;
+
+        @AuraEnabled
+        @InvocableVariable
+        public String status;
+
+        public EvaluationResult() {
+            this.exchangeOptions = new List<ProductSuggestion>();
+            this.alternativeProducts = new List<ProductSuggestion>();
+        }
+    }
+
+    @AuraEnabled
+    public class ProductSuggestion {
+        @AuraEnabled
+        public Id productId;
+
+        @AuraEnabled
+        public String name;
+
+        @AuraEnabled
+        public String productCode;
+
+        @AuraEnabled
+        public Decimal unitPrice;
+
+        @AuraEnabled
+        public String family;
+
+        @AuraEnabled
+        public String description;
+    }
+
+    private enum ReturnReasonCategory {
+        DEFECTIVE,
+        SIZE_FIT,
+        APPEARANCE,
+        UNWANTED,
+        OTHER
+    }
+
+    private static final Set<ReturnReasonCategory> ALL_REASON_CATEGORIES = new Set<ReturnReasonCategory>(ReturnReasonCategory.values());
+
+    private static final Map<String, Set<ReturnReasonCategory>> POLICY_REASON_MAP = buildPolicyReasonMap();
+
+    @AuraEnabled
+    public static EvaluationResult evaluateProductReturn(String productIdentifier, String returnReason) {
+        return handleEvaluation(productIdentifier, returnReason);
+    }
+
+    @InvocableMethod(label='返品ポリシー判定' description='商品名または商品コードと返品理由に基づいて返品可否を判定し、適切なガイダンスを返します。')
+    public static List<EvaluationResult> evaluate(List<EvaluationInput> inputs) {
+        List<EvaluationResult> results = new List<EvaluationResult>();
+        for (EvaluationInput input : inputs) {
+            results.add(handleEvaluation(input != null ? input.productIdentifier : null,
+                                         input != null ? input.returnReason : null));
+        }
+        return results;
+    }
+
+    private static EvaluationResult handleEvaluation(String productIdentifier, String returnReason) {
+        EvaluationResult result = new EvaluationResult();
+        result.productFound = false;
+        result.isReturnable = false;
+        result.reasonAccepted = false;
+        result.requiresReason = false;
+        result.status = 'UNRESOLVED';
+
+        String trimmedIdentifier = productIdentifier != null ? productIdentifier.trim() : null;
+        if (String.isBlank(trimmedIdentifier)) {
+            result.primaryMessage = '商品名または商品コードを入力してください。';
+            result.status = 'MISSING_IDENTIFIER';
+            return result;
+        }
+
+        Product2 product = findProduct(trimmedIdentifier);
+        if (product == null) {
+            result.primaryMessage = '該当する商品が見つかりませんでした。商品名または商品コードをご確認ください。';
+            result.status = 'PRODUCT_NOT_FOUND';
+            return result;
+        }
+
+        result.productFound = true;
+
+        StorePolicyProduct__c policyProduct = findPolicyForProduct(product.Id);
+        if (policyProduct == null || policyProduct.StorePolicy__r == null) {
+            result.primaryMessage = '申し訳ございません。この商品の返品ポリシー情報が見つかりませんでした。';
+            result.secondaryMessage = '代わりに交換はいかがでしょうか？';
+            result.exchangeOptions = findExchangeOptions(product);
+            if (!result.exchangeOptions.isEmpty()) {
+                result.exchangeMessage = '在庫がございます。サイズ／色違いの商品をお送りできますが、よろしいでしょうか？';
+            } else {
+                result.exchangeMessage = '申し訳ございません。現在交換用の在庫がございませんが、似たタイプの別商品をおすすめできます。';
+                result.alternativeProducts = findAlternativeProducts(product, null);
+                if (!result.alternativeProducts.isEmpty()) {
+                    result.alternativeMessage = buildAlternativesMessage(result.alternativeProducts);
+                }
+            }
+            result.status = 'POLICY_NOT_FOUND';
+            return result;
+        }
+
+        StorePolicy__c policy = policyProduct.StorePolicy__r;
+        result.policyName = policy.Name;
+        result.policyType = policy.PolicyType__c;
+        result.policyDescription = policy.Description__c;
+
+        Boolean policyAllowsReturn = isPolicyCurrentlyAllowingReturn(policyProduct, policy);
+        if (!policyAllowsReturn) {
+            result.primaryMessage = '申し訳ございませんが、この商品の返品はポリシーによりお受けできません。';
+            result.secondaryMessage = '代わりに交換はいかがでしょうか？';
+            result.exchangeOptions = findExchangeOptions(product);
+            if (!result.exchangeOptions.isEmpty()) {
+                result.exchangeMessage = '在庫がございます。サイズ／色違いの商品をお送りできますが、よろしいでしょうか？';
+            } else {
+                result.exchangeMessage = '申し訳ございません。現在交換用の在庫がございませんが、似たタイプの別商品をおすすめできます。';
+                result.alternativeProducts = findAlternativeProducts(product, getProductUnitPrice(product));
+                if (!result.alternativeProducts.isEmpty()) {
+                    result.alternativeMessage = buildAlternativesMessage(result.alternativeProducts);
+                }
+            }
+            result.status = 'RETURN_NOT_ALLOWED';
+            return result;
+        }
+
+        if (String.isBlank(returnReason)) {
+            result.primaryMessage = '返品理由をお聞かせください。';
+            result.isReturnable = true;
+            result.requiresReason = true;
+            result.status = 'ASK_REASON';
+            return result;
+        }
+
+        ReturnReasonCategory category = categorizeReason(returnReason);
+        result.reasonCategory = category != null ? category.name() : null;
+
+        Boolean reasonMatchesPolicy = category != null && isReasonAllowedByPolicy(policy.PolicyType__c, category);
+        if (reasonMatchesPolicy) {
+            result.isReturnable = true;
+            result.reasonAccepted = true;
+            result.primaryMessage = 'ご迷惑をおかけし、誠に申し訳ございません。すぐに新しい商品をお送りいたしますが、よろしいでしょうか？';
+            result.status = 'RETURN_APPROVED';
+            return result;
+        }
+
+        result.primaryMessage = '申し訳ございませんが、この商品の返品はポリシーによりお受けできません。';
+        result.secondaryMessage = '代わりに交換はいかがでしょうか？';
+        result.exchangeOptions = findExchangeOptions(product);
+        if (!result.exchangeOptions.isEmpty()) {
+            result.exchangeMessage = '在庫がございます。サイズ／色違いの商品をお送りできますが、よろしいでしょうか？';
+        } else {
+            result.exchangeMessage = '申し訳ございません。現在交換用の在庫がございませんが、似たタイプの別商品をおすすめできます。';
+            result.alternativeProducts = findAlternativeProducts(product, getProductUnitPrice(product));
+            if (!result.alternativeProducts.isEmpty()) {
+                result.alternativeMessage = buildAlternativesMessage(result.alternativeProducts);
+            }
+        }
+        result.status = 'RETURN_REJECTED_REASON';
+        return result;
+    }
+
+    private static Product2 findProduct(String productIdentifier) {
+        List<Product2> matches = [
+            SELECT Id, Name, ProductCode, Family, Description, ParentId, IsActive
+            FROM Product2
+            WHERE (ProductCode = :productIdentifier OR Name = :productIdentifier)
+            AND IsActive = true
+            LIMIT 1
+        ];
+
+        if (!matches.isEmpty()) {
+            return matches[0];
+        }
+
+        matches = [
+            SELECT Id, Name, ProductCode, Family, Description, ParentId, IsActive
+            FROM Product2
+            WHERE (ProductCode LIKE :('%' + productIdentifier + '%') OR Name LIKE :('%' + productIdentifier + '%'))
+            AND IsActive = true
+            ORDER BY CreatedDate DESC
+            LIMIT 1
+        ];
+
+        return matches.isEmpty() ? null : matches[0];
+    }
+
+    private static StorePolicyProduct__c findPolicyForProduct(Id productId) {
+        List<StorePolicyProduct__c> policies = [
+            SELECT Id, Product__c, StorePolicy__c, IsActive__c, Remarks__c,
+                   StorePolicy__r.Id,
+                   StorePolicy__r.Name,
+                   StorePolicy__r.PolicyType__c,
+                   StorePolicy__r.IsActive__c,
+                   StorePolicy__r.ValidFrom__c,
+                   StorePolicy__r.ValidTo__c,
+                   StorePolicy__r.Description__c
+            FROM StorePolicyProduct__c
+            WHERE Product__c = :productId
+            LIMIT 1
+        ];
+        return policies.isEmpty() ? null : policies[0];
+    }
+
+    private static Boolean isPolicyCurrentlyAllowingReturn(StorePolicyProduct__c policyProduct, StorePolicy__c policy) {
+        if (policyProduct == null || policy == null) {
+            return false;
+        }
+
+        if (!(policyProduct.IsActive__c == true && policy.IsActive__c == true)) {
+            return false;
+        }
+
+        Date today = System.today();
+        if ((policy.ValidFrom__c != null && policy.ValidFrom__c > today) ||
+            (policy.ValidTo__c != null && policy.ValidTo__c < today)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static ReturnReasonCategory categorizeReason(String reason) {
+        if (String.isBlank(reason)) {
+            return null;
+        }
+
+        String normalized = reason.toLowerCase();
+        if (normalized.contains('ほつれ') || normalized.contains('破れ') || normalized.contains('壊れ') ||
+            normalized.contains('不良') || normalized.contains('欠陥') || normalized.contains('fault') ||
+            normalized.contains('damage') || normalized.contains('damaged') || normalized.contains('defect')) {
+            return ReturnReasonCategory.DEFECTIVE;
+        }
+
+        if (normalized.contains('サイズ') || normalized.contains('大き') || normalized.contains('小さ') ||
+            normalized.contains('fit') || normalized.contains('きつ') || normalized.contains('ゆる') ||
+            normalized.contains('丈が') || normalized.contains('幅が')) {
+            return ReturnReasonCategory.SIZE_FIT;
+        }
+
+        if (normalized.contains('イメージ') || normalized.contains('色が') || normalized.contains('色違い') ||
+            normalized.contains('デザイン') || normalized.contains('思っていた') || normalized.contains('見た目') ||
+            normalized.contains('color')) {
+            return ReturnReasonCategory.APPEARANCE;
+        }
+
+        if (normalized.contains('不要') || normalized.contains('使わない') || normalized.contains('要らなく') ||
+            normalized.contains('間違って') || normalized.contains('キャンセル') || normalized.contains('気が変わった') ||
+            normalized.contains('不要になった') || normalized.contains('不要になりまし') || normalized.contains('不要です')) {
+            return ReturnReasonCategory.UNWANTED;
+        }
+
+        return ReturnReasonCategory.OTHER;
+    }
+
+    private static Boolean isReasonAllowedByPolicy(String policyType, ReturnReasonCategory category) {
+        if (category == null) {
+            return false;
+        }
+
+        if (String.isBlank(policyType)) {
+            return category != ReturnReasonCategory.OTHER;
+        }
+
+        String key = policyType.trim().toUpperCase();
+        if (POLICY_REASON_MAP.containsKey(key)) {
+            Set<ReturnReasonCategory> allowed = POLICY_REASON_MAP.get(key);
+            return allowed != null && allowed.contains(category);
+        }
+
+        return false;
+    }
+
+    private static Map<String, Set<ReturnReasonCategory>> buildPolicyReasonMap() {
+        Map<String, Set<ReturnReasonCategory>> mapping = new Map<String, Set<ReturnReasonCategory>>();
+        mapping.put('RETURN_ALL', new Set<ReturnReasonCategory>(ALL_REASON_CATEGORIES));
+        mapping.put('RETURN_DEFECTIVE_ONLY', new Set<ReturnReasonCategory>{ReturnReasonCategory.DEFECTIVE});
+        mapping.put('RETURN_DEFECTIVE_SIZE', new Set<ReturnReasonCategory>{ReturnReasonCategory.DEFECTIVE, ReturnReasonCategory.SIZE_FIT});
+        mapping.put('RETURN_SIZE_ONLY', new Set<ReturnReasonCategory>{ReturnReasonCategory.SIZE_FIT});
+        mapping.put('RETURN_APPEARANCE', new Set<ReturnReasonCategory>{ReturnReasonCategory.APPEARANCE});
+        mapping.put('RETURN_SATISFACTION', new Set<ReturnReasonCategory>{ReturnReasonCategory.APPEARANCE, ReturnReasonCategory.UNWANTED});
+        mapping.put('RETURN_UNWANTED', new Set<ReturnReasonCategory>{ReturnReasonCategory.UNWANTED});
+        mapping.put('RETURN_OTHER', new Set<ReturnReasonCategory>{ReturnReasonCategory.OTHER});
+        mapping.put('RETURN_DEFECTIVE_APPEARANCE', new Set<ReturnReasonCategory>{ReturnReasonCategory.DEFECTIVE, ReturnReasonCategory.APPEARANCE});
+        mapping.put('RETURN_DEFECTIVE_SATISFACTION', new Set<ReturnReasonCategory>{ReturnReasonCategory.DEFECTIVE, ReturnReasonCategory.APPEARANCE, ReturnReasonCategory.UNWANTED});
+        return mapping;
+    }
+
+    private static List<ProductSuggestion> findExchangeOptions(Product2 product) {
+        if (product == null) {
+            return new List<ProductSuggestion>();
+        }
+
+        Set<Id> parentIds = new Set<Id>();
+        if (product.ParentId != null) {
+            parentIds.add(product.ParentId);
+        } else {
+            parentIds.add(product.Id);
+        }
+
+        List<Product2> variationCandidates = [
+            SELECT Id, Name, ProductCode, Family, Description
+            FROM Product2
+            WHERE IsActive = true
+              AND Id != :product.Id
+              AND (
+                    ParentId IN :parentIds
+                 OR ParentId = :product.Id
+                 OR Id IN :parentIds
+              )
+            ORDER BY CreatedDate DESC
+            LIMIT 5
+        ];
+
+        List<ProductSuggestion> suggestions = new List<ProductSuggestion>();
+        for (Product2 variation : variationCandidates) {
+            ProductSuggestion suggestion = new ProductSuggestion();
+            suggestion.productId = variation.Id;
+            suggestion.name = variation.Name;
+            suggestion.productCode = variation.ProductCode;
+            suggestion.family = variation.Family;
+            suggestion.description = variation.Description;
+            suggestion.unitPrice = getProductUnitPrice(variation);
+            suggestions.add(suggestion);
+        }
+
+        return suggestions;
+    }
+
+    private static List<ProductSuggestion> findAlternativeProducts(Product2 product, Decimal basePrice) {
+        if (product == null) {
+            return new List<ProductSuggestion>();
+        }
+
+        Id standardPricebookId = getStandardPricebookIdSafe();
+        Decimal comparisonPrice = basePrice != null ? basePrice : getProductUnitPrice(product);
+
+        String family = product.Family;
+        List<ProductSuggestion> alternatives = new List<ProductSuggestion>();
+        if (String.isBlank(family)) {
+            return alternatives;
+        }
+
+        if (comparisonPrice != null && standardPricebookId != null) {
+            Decimal tolerance = comparisonPrice * 0.2;
+            Decimal minPrice = comparisonPrice - tolerance;
+            Decimal maxPrice = comparisonPrice + tolerance;
+            List<PricebookEntry> entries = [
+                SELECT Id, Product2.Id, Product2.Name, Product2.ProductCode, Product2.Family, Product2.Description, UnitPrice
+                FROM PricebookEntry
+                WHERE Pricebook2Id = :standardPricebookId
+                  AND Product2.IsActive = true
+                  AND Product2Id != :product.Id
+                  AND Product2.Family = :family
+                  AND UnitPrice >= :minPrice
+                  AND UnitPrice <= :maxPrice
+                ORDER BY ABS(UnitPrice - :comparisonPrice)
+                LIMIT 5
+            ];
+            for (PricebookEntry entry : entries) {
+                ProductSuggestion suggestion = new ProductSuggestion();
+                suggestion.productId = entry.Product2Id;
+                suggestion.name = entry.Product2.Name;
+                suggestion.productCode = entry.Product2.ProductCode;
+                suggestion.family = entry.Product2.Family;
+                suggestion.description = entry.Product2.Description;
+                suggestion.unitPrice = entry.UnitPrice;
+                alternatives.add(suggestion);
+            }
+        }
+
+        if (alternatives.isEmpty()) {
+            List<Product2> familyProducts = [
+                SELECT Id, Name, ProductCode, Family, Description
+                FROM Product2
+                WHERE IsActive = true
+                  AND Family = :family
+                  AND Id != :product.Id
+                ORDER BY CreatedDate DESC
+                LIMIT 5
+            ];
+            for (Product2 familyProduct : familyProducts) {
+                ProductSuggestion suggestion = new ProductSuggestion();
+                suggestion.productId = familyProduct.Id;
+                suggestion.name = familyProduct.Name;
+                suggestion.productCode = familyProduct.ProductCode;
+                suggestion.family = familyProduct.Family;
+                suggestion.description = familyProduct.Description;
+                suggestion.unitPrice = getProductUnitPrice(familyProduct);
+                alternatives.add(suggestion);
+            }
+        }
+
+        return alternatives;
+    }
+
+    private static String buildAlternativesMessage(List<ProductSuggestion> suggestions) {
+        if (suggestions == null || suggestions.isEmpty()) {
+            return null;
+        }
+        List<String> parts = new List<String>();
+        for (ProductSuggestion suggestion : suggestions) {
+            List<String> fragments = new List<String>();
+            if (!String.isBlank(suggestion.name)) {
+                fragments.add(suggestion.name);
+            }
+            if (!String.isBlank(suggestion.productCode)) {
+                fragments.add('商品コード: ' + suggestion.productCode);
+            }
+            if (suggestion.unitPrice != null) {
+                fragments.add('価格: ¥' + String.valueOf(Math.round(suggestion.unitPrice)));
+            }
+            parts.add(String.join(fragments, ' / '));
+        }
+        return '代替候補: ' + String.join(parts, '、 ');
+    }
+
+    private static Decimal getProductUnitPrice(Product2 product) {
+        Id standardPricebookId = getStandardPricebookIdSafe();
+        if (product == null || standardPricebookId == null) {
+            return null;
+        }
+
+        List<PricebookEntry> entries = [
+            SELECT UnitPrice
+            FROM PricebookEntry
+            WHERE Pricebook2Id = :standardPricebookId
+              AND Product2Id = :product.Id
+              AND IsActive = true
+            LIMIT 1
+        ];
+        return entries.isEmpty() ? null : entries[0].UnitPrice;
+    }
+
+    private static Id getStandardPricebookIdSafe() {
+        try {
+            if (Test.isRunningTest()) {
+                return Test.getStandardPricebookId();
+            }
+
+            List<Pricebook2> standard = [
+                SELECT Id
+                FROM Pricebook2
+                WHERE IsStandard = true
+                LIMIT 1
+            ];
+            return standard.isEmpty() ? null : standard[0].Id;
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+}

--- a/force-app/main/default/classes/ReturnEligibilityService.cls-meta.xml
+++ b/force-app/main/default/classes/ReturnEligibilityService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/ReturnEligibilityServiceTest.cls
+++ b/force-app/main/default/classes/ReturnEligibilityServiceTest.cls
@@ -1,0 +1,217 @@
+@IsTest
+private class ReturnEligibilityServiceTest {
+    @IsTest
+    static void testAskForReasonWhenReturnable() {
+        Test.startTest();
+        TestData data = TestData.setup();
+        ReturnEligibilityService.EvaluationResult result = ReturnEligibilityService.evaluateProductReturn(data.returnableProductCode, null);
+        Test.stopTest();
+
+        System.assertEquals(true, result.productFound, 'Product should be found.');
+        System.assertEquals(true, result.isReturnable, 'Policy should allow return.');
+        System.assertEquals(true, result.requiresReason, 'Should request reason when not provided.');
+        System.assertEquals('ASK_REASON', result.status);
+        System.assertEquals('返品理由をお聞かせください。', result.primaryMessage);
+    }
+
+    @IsTest
+    static void testApproveReturnWhenReasonMatchesPolicy() {
+        TestData data = TestData.setup();
+
+        Test.startTest();
+        ReturnEligibilityService.EvaluationResult result = ReturnEligibilityService.evaluateProductReturn(
+            data.returnableProductCode,
+            '糸のほつれがありました'
+        );
+        Test.stopTest();
+
+        System.assertEquals(true, result.productFound);
+        System.assertEquals(true, result.isReturnable);
+        System.assertEquals(true, result.reasonAccepted);
+        System.assertEquals('RETURN_APPROVED', result.status);
+        System.assertEquals('ご迷惑をおかけし、誠に申し訳ございません。すぐに新しい商品をお送りいたしますが、よろしいでしょうか？', result.primaryMessage);
+    }
+
+    @IsTest
+    static void testRejectReturnWhenReasonNotAllowed() {
+        TestData data = TestData.setup();
+
+        Test.startTest();
+        ReturnEligibilityService.EvaluationResult result = ReturnEligibilityService.evaluateProductReturn(
+            data.returnableProductCode,
+            '不要になったので返品したいです'
+        );
+        Test.stopTest();
+
+        System.assertEquals(true, result.productFound);
+        System.assertEquals(false, result.isReturnable);
+        System.assertEquals('RETURN_REJECTED_REASON', result.status);
+        System.assertEquals('申し訳ございませんが、この商品の返品はポリシーによりお受けできません。', result.primaryMessage);
+        System.assertEquals('代わりに交換はいかがでしょうか？', result.secondaryMessage);
+        System.assertEquals(true, result.exchangeOptions.size() > 0, 'Exchange options should be suggested.');
+    }
+
+    @IsTest
+    static void testRejectReturnWhenPolicyInactive() {
+        TestData data = TestData.setup();
+        deactivatePolicy(data.policyId);
+
+        Test.startTest();
+        ReturnEligibilityService.EvaluationResult result = ReturnEligibilityService.evaluateProductReturn(
+            data.returnableProductCode,
+            '糸のほつれがあります'
+        );
+        Test.stopTest();
+
+        System.assertEquals(false, result.isReturnable);
+        System.assertEquals('RETURN_NOT_ALLOWED', result.status);
+        System.assertEquals('申し訳ございませんが、この商品の返品はポリシーによりお受けできません。', result.primaryMessage);
+    }
+
+    @IsTest
+    static void testSuggestAlternativesWhenNoExchange() {
+        TestData data = TestData.setupNoExchange();
+
+        Test.startTest();
+        ReturnEligibilityService.EvaluationResult result = ReturnEligibilityService.evaluateProductReturn(
+            data.returnableProductCode,
+            '不要になりました'
+        );
+        Test.stopTest();
+
+        System.assertEquals(false, result.isReturnable);
+        System.assertEquals('RETURN_REJECTED_REASON', result.status);
+        System.assertEquals('申し訳ございません。現在交換用の在庫がございませんが、似たタイプの別商品をおすすめできます。', result.exchangeMessage);
+        System.assert(result.alternativeProducts.size() > 0, 'Alternative suggestions should be returned.');
+        System.assert(!String.isBlank(result.alternativeMessage), 'Alternative message should be populated.');
+    }
+
+    @IsTest
+    static void testProductNotFound() {
+        Test.startTest();
+        ReturnEligibilityService.EvaluationResult result = ReturnEligibilityService.evaluateProductReturn('UNKNOWN_CODE', null);
+        Test.stopTest();
+
+        System.assertEquals(false, result.productFound);
+        System.assertEquals('PRODUCT_NOT_FOUND', result.status);
+        System.assertEquals('該当する商品が見つかりませんでした。商品名または商品コードをご確認ください。', result.primaryMessage);
+    }
+
+    private static void deactivatePolicy(Id policyId) {
+        StorePolicy__c policy = [SELECT Id, IsActive__c FROM StorePolicy__c WHERE Id = :policyId];
+        policy.IsActive__c = false;
+        update policy;
+    }
+
+    private class TestData {
+        Id policyId;
+        String returnableProductCode;
+
+        static TestData setup() {
+            TestData data = new TestData();
+            data.initialize(true);
+            return data;
+        }
+
+        static TestData setupNoExchange() {
+            TestData data = new TestData();
+            data.initialize(false);
+            return data;
+        }
+
+        private void initialize(Boolean includeExchangeVariation) {
+            Id standardPricebookId = Test.getStandardPricebookId();
+
+            Product2 baseProduct = new Product2(
+                Name = 'Nova Knit Cardigan',
+                ProductCode = 'NKC-001',
+                Family = 'Apparel',
+                IsActive = true
+            );
+            insert baseProduct;
+
+            PricebookEntry baseEntry = new PricebookEntry(
+                Pricebook2Id = standardPricebookId,
+                Product2Id = baseProduct.Id,
+                UnitPrice = 9800,
+                IsActive = true,
+                UseStandardPrice = false
+            );
+            insert baseEntry;
+
+            StorePolicy__c policy = new StorePolicy__c(
+                Name = 'Defective Only Return',
+                PolicyType__c = 'RETURN_DEFECTIVE_ONLY',
+                IsActive__c = true,
+                ValidFrom__c = Date.today().addDays(-30),
+                ValidTo__c = Date.today().addDays(30),
+                Description__c = '不良品のみ返品可能です。'
+            );
+            insert policy;
+            this.policyId = policy.Id;
+
+            StorePolicyProduct__c mapping = new StorePolicyProduct__c(
+                Product__c = baseProduct.Id,
+                StorePolicy__c = policy.Id,
+                IsActive__c = true
+            );
+            insert mapping;
+
+            if (includeExchangeVariation) {
+                Product2 variation = new Product2(
+                    Name = 'Nova Knit Cardigan - Blue',
+                    ProductCode = 'NKC-001-BL',
+                    Family = 'Apparel',
+                    IsActive = true,
+                    ParentId = baseProduct.Id
+                );
+                insert variation;
+
+                PricebookEntry variationEntry = new PricebookEntry(
+                    Pricebook2Id = standardPricebookId,
+                    Product2Id = variation.Id,
+                    UnitPrice = 9800,
+                    IsActive = true,
+                    UseStandardPrice = false
+                );
+                insert variationEntry;
+            }
+
+            Product2 alternative1 = new Product2(
+                Name = 'Nova Knit Sweater',
+                ProductCode = 'NKS-100',
+                Family = 'Apparel',
+                IsActive = true
+            );
+            insert alternative1;
+
+            PricebookEntry alternativeEntry1 = new PricebookEntry(
+                Pricebook2Id = standardPricebookId,
+                Product2Id = alternative1.Id,
+                UnitPrice = 9500,
+                IsActive = true,
+                UseStandardPrice = false
+            );
+            insert alternativeEntry1;
+
+            Product2 alternative2 = new Product2(
+                Name = 'Nova Knit Hoodie',
+                ProductCode = 'NKH-200',
+                Family = 'Apparel',
+                IsActive = true
+            );
+            insert alternative2;
+
+            PricebookEntry alternativeEntry2 = new PricebookEntry(
+                Pricebook2Id = standardPricebookId,
+                Product2Id = alternative2.Id,
+                UnitPrice = 9900,
+                IsActive = true,
+                UseStandardPrice = false
+            );
+            insert alternativeEntry2;
+
+            this.returnableProductCode = baseProduct.ProductCode;
+        }
+    }
+}

--- a/force-app/main/default/classes/ReturnEligibilityServiceTest.cls-meta.xml
+++ b/force-app/main/default/classes/ReturnEligibilityServiceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
## Summary
- add an Apex service that evaluates return eligibility, provides policy-guided responses, and surfaces exchange or alternative product suggestions for Agentforce
- cover return approval, rejection, and fallback scenarios with dedicated Apex tests

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68f30d505f48832c88c229c6fcfff4a3