### PR TITLE
Add dedicated return order processing service

### DIFF
--- a/force-app/main/default/classes/ReturnOrderProcessingService.cls
+++ b/force-app/main/default/classes/ReturnOrderProcessingService.cls
@@ -1,0 +1,152 @@
+public with sharing class ReturnOrderProcessingService {
+    public class Request {
+        @AuraEnabled
+        public String orderNumber;
+
+        @AuraEnabled
+        public String productCode;
+
+        @AuraEnabled
+        public Decimal quantity;
+
+        @AuraEnabled
+        public String returnReason;
+    }
+
+    public class Response {
+        @AuraEnabled
+        public Boolean success;
+
+        @AuraEnabled
+        public String status;
+
+        @AuraEnabled
+        public String primaryMessage;
+
+        @AuraEnabled
+        public String secondaryMessage;
+
+        @AuraEnabled
+        public String returnOrderNumber;
+
+        @AuraEnabled
+        public ReturnEligibilityService.EvaluationResult evaluation;
+    }
+
+    private class FlowOutcome {
+        Boolean success = false;
+        String returnOrderNumber;
+        String errorMessage;
+    }
+
+    @AuraEnabled
+    public static Response processReturn(Request request) {
+        if (request == null) {
+            throw new AuraHandledException('返品手続きを進めるには注文情報が必要です。');
+        }
+
+        String normalizedOrderNumber = request.orderNumber != null ? request.orderNumber.trim() : null;
+        String normalizedProductCode = request.productCode != null ? request.productCode.trim() : null;
+        Decimal quantity = request.quantity;
+
+        validateInputs(normalizedOrderNumber, normalizedProductCode, quantity);
+
+        ReturnEligibilityService.EvaluationResult evaluation = ReturnEligibilityService.evaluateProductReturn(
+            normalizedProductCode,
+            request.returnReason
+        );
+
+        Response response = new Response();
+        response.evaluation = evaluation;
+
+        if (evaluation == null) {
+            response.success = false;
+            response.status = 'EVALUATION_FAILED';
+            response.primaryMessage = '返品手続きを進めることができませんでした。お手数ですが、再度お試しください。';
+            return response;
+        }
+
+        if (!(Boolean.TRUE.equals(evaluation.productFound) &&
+              Boolean.TRUE.equals(evaluation.isReturnable) &&
+              Boolean.TRUE.equals(evaluation.reasonAccepted))) {
+            response.success = false;
+            response.status = evaluation.status;
+            response.primaryMessage = evaluation.primaryMessage;
+            response.secondaryMessage = evaluation.secondaryMessage;
+            return response;
+        }
+
+        FlowOutcome outcome = executeReturnOrderFlow(
+            normalizedOrderNumber,
+            normalizedProductCode,
+            quantity,
+            request.returnReason
+        );
+
+        if (outcome.success) {
+            response.success = true;
+            response.status = 'RETURN_ORDER_CREATED';
+            response.returnOrderNumber = outcome.returnOrderNumber;
+            response.primaryMessage = buildSuccessMessage(outcome.returnOrderNumber);
+            response.secondaryMessage = null;
+        } else {
+            response.success = false;
+            response.status = 'RETURN_ORDER_FAILED';
+            response.returnOrderNumber = null;
+            response.primaryMessage = 'システムエラーにより返品手続きが完了しませんでした。お手数ですが、再度お試しください。';
+            response.secondaryMessage = String.isBlank(outcome.errorMessage) ? null : outcome.errorMessage;
+        }
+
+        return response;
+    }
+
+    private static void validateInputs(String orderNumber, String productCode, Decimal quantity) {
+        if (String.isBlank(orderNumber)) {
+            throw new AuraHandledException('返品手続きを進めるには注文番号が必要です。');
+        }
+
+        if (String.isBlank(productCode)) {
+            throw new AuraHandledException('返品手続きを進めるには商品コードが必要です。');
+        }
+
+        if (quantity == null || quantity <= 0) {
+            throw new AuraHandledException('返品数量は1以上の数値を指定してください。');
+        }
+    }
+
+    private static String buildSuccessMessage(String returnOrderNumber) {
+        String number = String.isBlank(returnOrderNumber) ? '不明' : returnOrderNumber;
+        return '返品手続きが完了しました。返品注文番号は『' + number + '』です。この番号をお控えください。担当者が確認次第、メールにてご連絡いたします。';
+    }
+
+    private static FlowOutcome executeReturnOrderFlow(String orderNumber,
+                                                       String productCode,
+                                                       Decimal quantity,
+                                                       String returnReason) {
+        FlowOutcome outcome = new FlowOutcome();
+        Map<String, Object> inputs = new Map<String, Object>{
+            'OrderNumber' => orderNumber,
+            'ProductCode' => productCode,
+            'Quantity' => quantity,
+            'ReturnReason' => returnReason
+        };
+
+        try {
+            Flow.Interview interview = Flow.Interview.createInterview('ReturnOrderFlow', inputs);
+            interview.start();
+
+            outcome.returnOrderNumber = (String) interview.getVariableValue('varReturnOrderNumber');
+            if (String.isBlank(outcome.returnOrderNumber)) {
+                outcome.success = false;
+                outcome.errorMessage = 'フローから返品注文番号が返されませんでした。';
+            } else {
+                outcome.success = true;
+            }
+        } catch (Exception e) {
+            outcome.success = false;
+            outcome.errorMessage = e != null ? e.getMessage() : null;
+        }
+
+        return outcome;
+    }
+}

--- a/force-app/main/default/classes/ReturnOrderProcessingService.cls
+++ b/force-app/main/default/classes/ReturnOrderProcessingService.cls
@@ -30,12 +30,16 @@ public with sharing class ReturnOrderProcessingService {
         public String returnOrderNumber;
 
         @AuraEnabled
+        public String caseNumber;
+
+        @AuraEnabled
         public ReturnEligibilityService.EvaluationResult evaluation;
     }
 
     private class FlowOutcome {
         Boolean success = false;
         String returnOrderNumber;
+        String caseNumber;
         String errorMessage;
     }
 
@@ -47,13 +51,14 @@ public with sharing class ReturnOrderProcessingService {
 
         String normalizedOrderNumber = request.orderNumber != null ? request.orderNumber.trim() : null;
         String normalizedProductCode = request.productCode != null ? request.productCode.trim() : null;
+        String normalizedReturnReason = request.returnReason != null ? request.returnReason.trim() : null;
         Decimal quantity = request.quantity;
 
         validateInputs(normalizedOrderNumber, normalizedProductCode, quantity);
 
         ReturnEligibilityService.EvaluationResult evaluation = ReturnEligibilityService.evaluateProductReturn(
             normalizedProductCode,
-            request.returnReason
+            normalizedReturnReason
         );
 
         Response response = new Response();
@@ -80,19 +85,21 @@ public with sharing class ReturnOrderProcessingService {
             normalizedOrderNumber,
             normalizedProductCode,
             quantity,
-            request.returnReason
+            normalizedReturnReason
         );
 
         if (outcome.success) {
             response.success = true;
             response.status = 'RETURN_ORDER_CREATED';
             response.returnOrderNumber = outcome.returnOrderNumber;
+            response.caseNumber = outcome.caseNumber;
             response.primaryMessage = buildSuccessMessage(outcome.returnOrderNumber);
             response.secondaryMessage = null;
         } else {
             response.success = false;
             response.status = 'RETURN_ORDER_FAILED';
             response.returnOrderNumber = null;
+            response.caseNumber = null;
             response.primaryMessage = 'システムエラーにより返品手続きが完了しませんでした。お手数ですが、再度お試しください。';
             response.secondaryMessage = String.isBlank(outcome.errorMessage) ? null : outcome.errorMessage;
         }
@@ -136,6 +143,7 @@ public with sharing class ReturnOrderProcessingService {
             interview.start();
 
             outcome.returnOrderNumber = (String) interview.getVariableValue('varReturnOrderNumber');
+            outcome.caseNumber = (String) interview.getVariableValue('varCaseNumber');
             if (String.isBlank(outcome.returnOrderNumber)) {
                 outcome.success = false;
                 outcome.errorMessage = 'フローから返品注文番号が返されませんでした。';

--- a/force-app/main/default/classes/ReturnOrderProcessingService.cls-meta.xml
+++ b/force-app/main/default/classes/ReturnOrderProcessingService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/ReturnOrderProcessingServiceTest.cls
+++ b/force-app/main/default/classes/ReturnOrderProcessingServiceTest.cls
@@ -9,7 +9,7 @@ private class ReturnOrderProcessingServiceTest {
         request.orderNumber = 'ORD-10001';
         request.productCode = data.returnableProductCode;
         request.quantity = 1;
-        request.returnReason = '糸のほつれがありました';
+        request.returnReason = '  糸のほつれがありました  ';
 
         Test.startTest();
         ReturnOrderProcessingService.Response response = ReturnOrderProcessingService.processReturn(request);
@@ -18,6 +18,7 @@ private class ReturnOrderProcessingServiceTest {
         System.assertEquals(true, response.success, 'Response should indicate success.');
         System.assertEquals('RETURN_ORDER_CREATED', response.status, 'Status should indicate creation.');
         System.assertEquals('RO-000123', response.returnOrderNumber, 'Return order number should come from flow.');
+        System.assertEquals('00001005', response.caseNumber, 'Case number should be surfaced from the flow.');
         System.assertEquals(
             '返品手続きが完了しました。返品注文番号は『RO-000123』です。この番号をお控えください。担当者が確認次第、メールにてご連絡いたします。',
             response.primaryMessage
@@ -45,6 +46,7 @@ private class ReturnOrderProcessingServiceTest {
         System.assertEquals(false, response.success, 'Failure should be reported.');
         System.assertEquals('RETURN_ORDER_FAILED', response.status, 'Status should indicate flow failure.');
         System.assertEquals(null, response.returnOrderNumber, 'Return order number should be empty.');
+        System.assertEquals(null, response.caseNumber, 'Case number should be empty when the flow fails.');
         System.assertEquals(
             'システムエラーにより返品手続きが完了しませんでした。お手数ですが、再度お試しください。',
             response.primaryMessage
@@ -228,7 +230,8 @@ private class ReturnOrderProcessingServiceTest {
             System.assertEquals('糸のほつれがありました', (String) inputs.get('ReturnReason'));
 
             return new Map<String, Object>{
-                'varReturnOrderNumber' => 'RO-000123'
+                'varReturnOrderNumber' => 'RO-000123',
+                'varCaseNumber' => '00001005'
             };
         }
 

--- a/force-app/main/default/classes/ReturnOrderProcessingServiceTest.cls
+++ b/force-app/main/default/classes/ReturnOrderProcessingServiceTest.cls
@@ -1,0 +1,264 @@
+@IsTest
+private class ReturnOrderProcessingServiceTest {
+    @IsTest
+    static void testProcessReturnSuccess() {
+        TestData data = TestData.setup();
+        Test.setMock(Flow.Interview.Mock.class, new SuccessfulReturnOrderFlowMock());
+
+        ReturnOrderProcessingService.Request request = new ReturnOrderProcessingService.Request();
+        request.orderNumber = 'ORD-10001';
+        request.productCode = data.returnableProductCode;
+        request.quantity = 1;
+        request.returnReason = '糸のほつれがありました';
+
+        Test.startTest();
+        ReturnOrderProcessingService.Response response = ReturnOrderProcessingService.processReturn(request);
+        Test.stopTest();
+
+        System.assertEquals(true, response.success, 'Response should indicate success.');
+        System.assertEquals('RETURN_ORDER_CREATED', response.status, 'Status should indicate creation.');
+        System.assertEquals('RO-000123', response.returnOrderNumber, 'Return order number should come from flow.');
+        System.assertEquals(
+            '返品手続きが完了しました。返品注文番号は『RO-000123』です。この番号をお控えください。担当者が確認次第、メールにてご連絡いたします。',
+            response.primaryMessage
+        );
+        System.assertEquals(null, response.secondaryMessage, 'Secondary message should be cleared.');
+        System.assertNotEquals(null, response.evaluation, 'Evaluation result should be returned.');
+        System.assertEquals(true, response.evaluation.reasonAccepted, 'Reason should have been accepted.');
+    }
+
+    @IsTest
+    static void testProcessReturnFlowFailure() {
+        TestData data = TestData.setup();
+        Test.setMock(Flow.Interview.Mock.class, new FailingReturnOrderFlowMock());
+
+        ReturnOrderProcessingService.Request request = new ReturnOrderProcessingService.Request();
+        request.orderNumber = 'ORD-20001';
+        request.productCode = data.returnableProductCode;
+        request.quantity = 1;
+        request.returnReason = '糸のほつれがあります';
+
+        Test.startTest();
+        ReturnOrderProcessingService.Response response = ReturnOrderProcessingService.processReturn(request);
+        Test.stopTest();
+
+        System.assertEquals(false, response.success, 'Failure should be reported.');
+        System.assertEquals('RETURN_ORDER_FAILED', response.status, 'Status should indicate flow failure.');
+        System.assertEquals(null, response.returnOrderNumber, 'Return order number should be empty.');
+        System.assertEquals(
+            'システムエラーにより返品手続きが完了しませんでした。お手数ですが、再度お試しください。',
+            response.primaryMessage
+        );
+        System.assertEquals('Flow execution failed', response.secondaryMessage, 'Error detail should surface flow error.');
+        System.assertEquals(true, response.evaluation.reasonAccepted, 'Evaluation should still indicate accepted reason.');
+    }
+
+    @IsTest
+    static void testDoesNotInvokeFlowWhenEvaluationRejects() {
+        TestData data = TestData.setup();
+        FlowInvocationTracker.wasInvoked = false;
+        Test.setMock(Flow.Interview.Mock.class, new TrackingFlowMock());
+
+        ReturnOrderProcessingService.Request request = new ReturnOrderProcessingService.Request();
+        request.orderNumber = 'ORD-30001';
+        request.productCode = data.returnableProductCode;
+        request.quantity = 1;
+        request.returnReason = '不要になりました';
+
+        Test.startTest();
+        ReturnOrderProcessingService.Response response = ReturnOrderProcessingService.processReturn(request);
+        Test.stopTest();
+
+        System.assertEquals(false, response.success, 'Response should be unsuccessful.');
+        System.assertEquals('RETURN_REJECTED_REASON', response.status, 'Status should come from evaluation.');
+        System.assertEquals('申し訳ございませんが、この商品の返品はポリシーによりお受けできません。', response.primaryMessage);
+        System.assertEquals(false, FlowInvocationTracker.wasInvoked, 'Flow should not run when evaluation rejects the request.');
+    }
+
+    @IsTest
+    static void testValidatesInputs() {
+        TestData data = TestData.setup();
+
+        ReturnOrderProcessingService.Request missingOrder = new ReturnOrderProcessingService.Request();
+        missingOrder.productCode = data.returnableProductCode;
+        missingOrder.quantity = 1;
+        missingOrder.returnReason = '糸のほつれがあります';
+
+        try {
+            ReturnOrderProcessingService.processReturn(missingOrder);
+            System.assert(false, 'Missing order number should throw an exception.');
+        } catch (AuraHandledException e) {
+            System.assert(e.getMessage().contains('注文番号'), 'Message should mention order number.');
+        }
+
+        ReturnOrderProcessingService.Request missingProduct = new ReturnOrderProcessingService.Request();
+        missingProduct.orderNumber = 'ORD-40001';
+        missingProduct.quantity = 1;
+        missingProduct.returnReason = '糸のほつれがあります';
+
+        try {
+            ReturnOrderProcessingService.processReturn(missingProduct);
+            System.assert(false, 'Missing product code should throw an exception.');
+        } catch (AuraHandledException e) {
+            System.assert(e.getMessage().contains('商品コード'), 'Message should mention product code.');
+        }
+
+        ReturnOrderProcessingService.Request invalidQuantity = new ReturnOrderProcessingService.Request();
+        invalidQuantity.orderNumber = 'ORD-40002';
+        invalidQuantity.productCode = data.returnableProductCode;
+        invalidQuantity.quantity = 0;
+        invalidQuantity.returnReason = '糸のほつれがあります';
+
+        try {
+            ReturnOrderProcessingService.processReturn(invalidQuantity);
+            System.assert(false, 'Invalid quantity should throw an exception.');
+        } catch (AuraHandledException e) {
+            System.assert(e.getMessage().contains('返品数量'), 'Message should mention quantity.');
+        }
+    }
+
+    private class TestData {
+        Id policyId;
+        String returnableProductCode;
+
+        static TestData setup() {
+            TestData data = new TestData();
+            data.initialize();
+            return data;
+        }
+
+        private void initialize() {
+            Id standardPricebookId = Test.getStandardPricebookId();
+
+            Product2 baseProduct = new Product2(
+                Name = 'Nova Knit Cardigan',
+                ProductCode = 'NKC-001',
+                Family = 'Apparel',
+                IsActive = true
+            );
+            insert baseProduct;
+
+            PricebookEntry baseEntry = new PricebookEntry(
+                Pricebook2Id = standardPricebookId,
+                Product2Id = baseProduct.Id,
+                UnitPrice = 9800,
+                IsActive = true,
+                UseStandardPrice = false
+            );
+            insert baseEntry;
+
+            StorePolicy__c policy = new StorePolicy__c(
+                Name = 'Defective Only Return',
+                PolicyType__c = 'RETURN_DEFECTIVE_ONLY',
+                IsActive__c = true,
+                ValidFrom__c = Date.today().addDays(-30),
+                ValidTo__c = Date.today().addDays(30),
+                Description__c = '不良品のみ返品可能です。'
+            );
+            insert policy;
+            this.policyId = policy.Id;
+
+            StorePolicyProduct__c mapping = new StorePolicyProduct__c(
+                Product__c = baseProduct.Id,
+                StorePolicy__c = policy.Id,
+                IsActive__c = true
+            );
+            insert mapping;
+
+            Product2 variation = new Product2(
+                Name = 'Nova Knit Cardigan - Blue',
+                ProductCode = 'NKC-001-BL',
+                Family = 'Apparel',
+                IsActive = true
+            );
+            insert variation;
+
+            PricebookEntry variationEntry = new PricebookEntry(
+                Pricebook2Id = standardPricebookId,
+                Product2Id = variation.Id,
+                UnitPrice = 9800,
+                IsActive = true,
+                UseStandardPrice = false
+            );
+            insert variationEntry;
+
+            Product2 alternative1 = new Product2(
+                Name = 'Nova Knit Sweater',
+                ProductCode = 'NKS-100',
+                Family = 'Apparel',
+                IsActive = true
+            );
+            insert alternative1;
+
+            PricebookEntry alternativeEntry1 = new PricebookEntry(
+                Pricebook2Id = standardPricebookId,
+                Product2Id = alternative1.Id,
+                UnitPrice = 9500,
+                IsActive = true,
+                UseStandardPrice = false
+            );
+            insert alternativeEntry1;
+
+            Product2 alternative2 = new Product2(
+                Name = 'Nova Knit Hoodie',
+                ProductCode = 'NKH-200',
+                Family = 'Apparel',
+                IsActive = true
+            );
+            insert alternative2;
+
+            PricebookEntry alternativeEntry2 = new PricebookEntry(
+                Pricebook2Id = standardPricebookId,
+                Product2Id = alternative2.Id,
+                UnitPrice = 9900,
+                IsActive = true,
+                UseStandardPrice = false
+            );
+            insert alternativeEntry2;
+
+            this.returnableProductCode = baseProduct.ProductCode;
+        }
+    }
+
+    private class SuccessfulReturnOrderFlowMock implements Flow.Interview.Mock {
+        public Map<String, Object> start(Map<String, Object> inputs) {
+            System.assertEquals('ORD-10001', (String) inputs.get('OrderNumber'));
+            System.assertEquals('NKC-001', (String) inputs.get('ProductCode'));
+            System.assertEquals(Decimal.valueOf('1'), (Decimal) inputs.get('Quantity'));
+            System.assertEquals('糸のほつれがありました', (String) inputs.get('ReturnReason'));
+
+            return new Map<String, Object>{
+                'varReturnOrderNumber' => 'RO-000123'
+            };
+        }
+
+        public Map<String, Object> resume(Map<String, Object> inputs) {
+            return null;
+        }
+    }
+
+    private class FailingReturnOrderFlowMock implements Flow.Interview.Mock {
+        public Map<String, Object> start(Map<String, Object> inputs) {
+            throw new AuraHandledException('Flow execution failed');
+        }
+
+        public Map<String, Object> resume(Map<String, Object> inputs) {
+            return null;
+        }
+    }
+
+    private class TrackingFlowMock implements Flow.Interview.Mock {
+        public Map<String, Object> start(Map<String, Object> inputs) {
+            FlowInvocationTracker.wasInvoked = true;
+            return new Map<String, Object>();
+        }
+
+        public Map<String, Object> resume(Map<String, Object> inputs) {
+            return null;
+        }
+    }
+
+    private class FlowInvocationTracker {
+        static Boolean wasInvoked = false;
+    }
+}

--- a/force-app/main/default/classes/ReturnOrderProcessingServiceTest.cls-meta.xml
+++ b/force-app/main/default/classes/ReturnOrderProcessingServiceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
## Summary
- restore ReturnEligibilityService to focus on return eligibility evaluation without invoking the flow
- add ReturnOrderProcessingService to execute ReturnOrderFlow for approved returns and provide user-facing messaging
- cover success, failure, and validation paths with dedicated Apex unit tests for the new service

## Testing
- Not run (Salesforce Apex tests require an org)

------
https://chatgpt.com/codex/tasks/task_e_68f3368a9a24832cb2028c0e5fd9a6af