### PR TITLE
Localize return reason category labels

### DIFF
--- a/force-app/main/default/classes/ReturnEligibilityService.cls
+++ b/force-app/main/default/classes/ReturnEligibilityService.cls
@@ -81,9 +81,15 @@ public with sharing class ReturnEligibilityService {
         @InvocableVariable
         public String status;
 
+        // ユーザーが選択可能な返品理由カテゴリ一覧です。
+        @AuraEnabled
+        @InvocableVariable
+        public List<String> availableReasonCategories;
+
         public EvaluationResult() {
             this.exchangeOptions = new List<ProductSuggestion>();
             this.alternativeProducts = new List<ProductSuggestion>();
+            this.availableReasonCategories = new List<String>();
         }
     }
 
@@ -122,6 +128,10 @@ public with sharing class ReturnEligibilityService {
     }
 
     private static final Set<ReturnReasonCategory> ALL_REASON_CATEGORIES = new Set<ReturnReasonCategory>(ReturnReasonCategory.values());
+
+    private static final Map<ReturnReasonCategory, String> CATEGORY_LABELS = buildCategoryLabels();
+
+    private static final Map<String, ReturnReasonCategory> LABEL_TO_CATEGORY = buildLabelToCategoryMap();
 
     private static final Map<String, Set<ReturnReasonCategory>> POLICY_REASON_MAP = buildPolicyReasonMap();
 
@@ -206,17 +216,27 @@ public with sharing class ReturnEligibilityService {
         }
 
         if (String.isBlank(returnReason)) {
-            result.primaryMessage = '返品理由をお聞かせください。';
+            result.primaryMessage = '返品理由カテゴリを選択してください。';
             result.isReturnable = true;
             result.requiresReason = true;
+            result.availableReasonCategories = getAvailableReasonCategories();
             result.status = 'ASK_REASON';
             return result;
         }
 
-        ReturnReasonCategory category = categorizeReason(returnReason);
-        result.reasonCategory = category != null ? category.name() : null;
+        String normalizedReason = returnReason != null ? returnReason.trim() : null;
+        ReturnReasonCategory category = parseReasonCategory(normalizedReason);
+        if (category == null) {
+            result.primaryMessage = '選択された返品カテゴリを認識できません。もう一度選択してください。';
+            result.requiresReason = true;
+            result.availableReasonCategories = getAvailableReasonCategories();
+            result.status = 'INVALID_REASON_CATEGORY';
+            result.reasonCategory = normalizedReason;
+            return result;
+        }
+        result.reasonCategory = CATEGORY_LABELS.get(category);
 
-        Boolean reasonMatchesPolicy = category != null && isReasonAllowedByPolicy(policy.PolicyType__c, category);
+        Boolean reasonMatchesPolicy = isReasonAllowedByPolicy(policy.PolicyType__c, category);
         if (reasonMatchesPolicy) {
             result.isReturnable = true;
             result.reasonAccepted = true;
@@ -301,39 +321,6 @@ public with sharing class ReturnEligibilityService {
         return true;
     }
 
-    private static ReturnReasonCategory categorizeReason(String reason) {
-        if (String.isBlank(reason)) {
-            return null;
-        }
-
-        String normalized = reason.toLowerCase();
-        if (normalized.contains('ほつれ') || normalized.contains('破れ') || normalized.contains('壊れ') ||
-            normalized.contains('不良') || normalized.contains('欠陥') || normalized.contains('fault') ||
-            normalized.contains('damage') || normalized.contains('damaged') || normalized.contains('defect')) {
-            return ReturnReasonCategory.DEFECTIVE;
-        }
-
-        if (normalized.contains('サイズ') || normalized.contains('大き') || normalized.contains('小さ') ||
-            normalized.contains('fit') || normalized.contains('きつ') || normalized.contains('ゆる') ||
-            normalized.contains('丈が') || normalized.contains('幅が')) {
-            return ReturnReasonCategory.SIZE_FIT;
-        }
-
-        if (normalized.contains('イメージ') || normalized.contains('色が') || normalized.contains('色違い') ||
-            normalized.contains('デザイン') || normalized.contains('思っていた') || normalized.contains('見た目') ||
-            normalized.contains('color')) {
-            return ReturnReasonCategory.APPEARANCE;
-        }
-
-        if (normalized.contains('不要') || normalized.contains('使わない') || normalized.contains('要らなく') ||
-            normalized.contains('間違って') || normalized.contains('キャンセル') || normalized.contains('気が変わった') ||
-            normalized.contains('不要になった') || normalized.contains('不要になりまし') || normalized.contains('不要です')) {
-            return ReturnReasonCategory.UNWANTED;
-        }
-
-        return ReturnReasonCategory.OTHER;
-    }
-
     private static Boolean isReasonAllowedByPolicy(String policyType, ReturnReasonCategory category) {
         if (category == null) {
             return false;
@@ -350,6 +337,82 @@ public with sharing class ReturnEligibilityService {
         }
 
         return false;
+    }
+
+    private static ReturnReasonCategory parseReasonCategory(String reasonValue) {
+        if (String.isBlank(reasonValue)) {
+            return null;
+        }
+
+        String candidate = extractCategoryToken(reasonValue);
+        if (String.isBlank(candidate)) {
+            return null;
+        }
+
+        String normalized = candidate.replace('-', '_').replace(' ', '_').toUpperCase();
+        try {
+            return ReturnReasonCategory.valueOf(normalized);
+        } catch (Exception ex) {
+            if (LABEL_TO_CATEGORY.containsKey(candidate)) {
+                return LABEL_TO_CATEGORY.get(candidate);
+            }
+            return null;
+        }
+    }
+
+    private static String extractCategoryToken(String rawValue) {
+        if (String.isBlank(rawValue)) {
+            return null;
+        }
+
+        String trimmed = rawValue.trim();
+        if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
+            try {
+                Map<String, Object> payload = (Map<String, Object>)JSON.deserializeUntyped(trimmed);
+                if (payload != null) {
+                    Object categoryValue = payload.get('category');
+                    if (categoryValue instanceof String) {
+                        String categoryString = ((String)categoryValue).trim();
+                        if (!String.isBlank(categoryString)) {
+                            return categoryString;
+                        }
+                    }
+                }
+            } catch (Exception ex) {
+                // フォールバックとして JSON 文字列全体を後続の処理へ渡します。
+            }
+        }
+
+        return trimmed;
+    }
+
+    private static List<String> getAvailableReasonCategories() {
+        List<String> categories = new List<String>();
+        for (ReturnReasonCategory category : ReturnReasonCategory.values()) {
+            categories.add(CATEGORY_LABELS.get(category));
+        }
+        return categories;
+    }
+
+    private static Map<ReturnReasonCategory, String> buildCategoryLabels() {
+        Map<ReturnReasonCategory, String> labels = new Map<ReturnReasonCategory, String>();
+        labels.put(ReturnReasonCategory.DEFECTIVE, '不良・破損');
+        labels.put(ReturnReasonCategory.SIZE_FIT, 'サイズが合わない');
+        labels.put(ReturnReasonCategory.APPEARANCE, 'イメージと違う');
+        labels.put(ReturnReasonCategory.UNWANTED, '不要になった');
+        labels.put(ReturnReasonCategory.OTHER, 'その他');
+        return labels;
+    }
+
+    private static Map<String, ReturnReasonCategory> buildLabelToCategoryMap() {
+        Map<String, ReturnReasonCategory> mapping = new Map<String, ReturnReasonCategory>();
+        for (ReturnReasonCategory category : ReturnReasonCategory.values()) {
+            String label = CATEGORY_LABELS.get(category);
+            if (!String.isBlank(label)) {
+                mapping.put(label, category);
+            }
+        }
+        return mapping;
     }
 
     private static Map<String, Set<ReturnReasonCategory>> buildPolicyReasonMap() {


### PR DESCRIPTION
## Summary
- provide Japanese labels for return reason options so chat flows present localized choices
- support parsing Japanese selections back into enum categories while continuing to accept legacy English values
- accept JSON return-reason payloads and extract the category token before evaluation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f34ab3d16c832cabc335a52187441c