### PR TITLE
Initialize returns chat with Agentforce notice and composer prefill

### DIFF
--- a/force-app/main/default/lwc/agentforceChat/__tests__/agentforceChat.test.js
+++ b/force-app/main/default/lwc/agentforceChat/__tests__/agentforceChat.test.js
@@ -168,6 +168,47 @@ describe('c-agentforce-chat', () => {
         expect(agentMessage.textContent).toBe('Agentforce request failed');
     });
 
+    it('initializes the session and renders notice messages from the start session response', async () => {
+        const element = createElement('c-agentforce-chat', {
+            is: AgentforceChat
+        });
+        element.botId = 'bot-notice';
+        document.body.appendChild(element);
+
+        getConfigAdapter.emit({
+            startSessionEndpointUrl: 'https://example.com/sessions',
+            messagesEndpointUrl: 'https://example.com/messages',
+            botId: 'bot-notice'
+        });
+
+        mockStartSession.mockResolvedValueOnce({
+            sessionId: 'session-notice',
+            messagesUrl: 'https://example.com/messages/session-notice',
+            data: {
+                session: {
+                    noticeMessages: [
+                        '返品・交換サポートへようこそ。',
+                        { message: '注文番号を入力してください。', type: 'notice' }
+                    ]
+                }
+            }
+        });
+
+        await flushPromises();
+
+        await element.initializeConversation();
+        await flushPromises();
+
+        expect(mockStartSession).toHaveBeenCalledTimes(1);
+
+        const agentMessages = Array.from(
+            element.shadowRoot.querySelectorAll('div[data-role="agent"] .message-body')
+        ).map((node) => node.textContent);
+
+        expect(agentMessages).toContain('返品・交換サポートへようこそ。');
+        expect(agentMessages).toContain('注文番号を入力してください。');
+    });
+
     it('builds the messages endpoint from configured metadata when the session response omits URLs', async () => {
         const element = createElement('c-agentforce-chat', {
             is: AgentforceChat
@@ -316,5 +357,19 @@ describe('c-agentforce-chat', () => {
 
         const agentMessage = element.shadowRoot.querySelector('div[data-role="agent"] .message-body');
         expect(agentMessage.textContent).toBe('Acknowledged');
+    });
+
+    it('prefills the composer when prefillDraftMessage is invoked', async () => {
+        const element = createElement('c-agentforce-chat', {
+            is: AgentforceChat
+        });
+        document.body.appendChild(element);
+
+        element.prefillDraftMessage('00099999');
+
+        await flushPromises();
+
+        const textarea = element.shadowRoot.querySelector('lightning-textarea');
+        expect(textarea.value).toBe('00099999');
     });
 });

--- a/force-app/main/default/lwc/agentforceChat/agentforceChat.js
+++ b/force-app/main/default/lwc/agentforceChat/agentforceChat.js
@@ -139,6 +139,24 @@ export default class AgentforceChat extends LightningElement {
         this.draftMessage = event.target.value;
     }
 
+    @api
+    async initializeConversation() {
+        await this.ensureSession();
+    }
+
+    @api
+    prefillDraftMessage(value) {
+        this.draftMessage = this.normalizeMessageContent(value);
+    }
+
+    @api
+    focusComposer() {
+        const composerInput = this.template.querySelector('[data-id="composer-input"]');
+        if (composerInput && typeof composerInput.focus === 'function') {
+            composerInput.focus();
+        }
+    }
+
     async handleSend() {
         const draft = this.draftMessage;
         this.draftMessage = '';
@@ -274,6 +292,7 @@ export default class AgentforceChat extends LightningElement {
         this.sessionId = sessionId;
         this.sessionKey = result?.externalSessionKey || payload.externalSessionKey;
         this.messagesEndpoint = this.resolveMessagesEndpoint(result, sessionId, startSessionEndpoint);
+        this.appendInitialMessagesFromStartSession(result);
     }
 
     buildStartSessionEndpoint(template, botId) {
@@ -459,6 +478,165 @@ export default class AgentforceChat extends LightningElement {
             return error.message;
         }
         return 'Unexpected error';
+    }
+
+    appendInitialMessagesFromStartSession(result) {
+        const initialMessages = this.extractInitialMessagesFromStartSession(result);
+        if (!initialMessages.length) {
+            return;
+        }
+
+        const deduped = this.filterOutDuplicateMessages(initialMessages);
+        if (!deduped.length) {
+            return;
+        }
+
+        this.messages = [...this.messages, ...deduped];
+    }
+
+    extractInitialMessagesFromStartSession(result) {
+        if (!result) {
+            return [];
+        }
+
+        let payloads = [];
+
+        if (result.data && typeof result.data === 'object') {
+            payloads = this.collectInitialMessagePayloadsFromSource(result.data);
+        }
+
+        if (!payloads.length && result.body) {
+            const parsedBody = this.safeParseJson(result.body);
+            if (parsedBody && typeof parsedBody === 'object') {
+                payloads = this.collectInitialMessagePayloadsFromSource(parsedBody);
+            }
+        }
+
+        if (!payloads.length) {
+            return [];
+        }
+
+        return this.buildAgentResponses({ messages: payloads });
+    }
+
+    collectInitialMessagePayloadsFromSource(source) {
+        if (!source || typeof source !== 'object') {
+            return [];
+        }
+
+        const payloads = [];
+        const containers = [source];
+
+        if (source.session && typeof source.session === 'object') {
+            containers.push(source.session);
+        }
+
+        if (Array.isArray(source.sessions)) {
+            source.sessions.forEach((sessionEntry) => {
+                if (sessionEntry && typeof sessionEntry === 'object') {
+                    containers.push(sessionEntry);
+                }
+            });
+        }
+
+        const keyConfig = [
+            { key: 'noticeMessages', type: 'notice' },
+            { key: 'systemMessages', type: 'system' },
+            { key: 'messages', type: '' },
+            { key: 'initialMessages', type: '' },
+            { key: 'welcomeMessages', type: '' },
+            { key: 'preSessionMessages', type: '' },
+            { key: 'message', type: '' }
+        ];
+
+        containers.forEach((container) => {
+            keyConfig.forEach(({ key, type }) => {
+                if (!container || !Object.prototype.hasOwnProperty.call(container, key)) {
+                    return;
+                }
+
+                const normalized = this.normalizeInitialMessageValue(container[key], type);
+                if (normalized.length) {
+                    payloads.push(...normalized);
+                }
+            });
+        });
+
+        return payloads;
+    }
+
+    normalizeInitialMessageValue(value, fallbackType) {
+        const values = Array.isArray(value) ? value : [value];
+        return values
+            .map((entry) => this.normalizeInitialMessageEntry(entry, fallbackType))
+            .filter(Boolean);
+    }
+
+    normalizeInitialMessageEntry(entry, fallbackType) {
+        if (entry === null || entry === undefined) {
+            return undefined;
+        }
+
+        if (typeof entry === 'string') {
+            const trimmed = entry.trim();
+            if (!trimmed) {
+                return undefined;
+            }
+            if (fallbackType) {
+                return { type: fallbackType, message: trimmed };
+            }
+            return trimmed;
+        }
+
+        if (typeof entry === 'object') {
+            const normalized = { ...entry };
+            if (!normalized.type && fallbackType) {
+                normalized.type = fallbackType;
+            }
+            return normalized;
+        }
+
+        return undefined;
+    }
+
+    safeParseJson(value) {
+        if (!value || typeof value !== 'string') {
+            return undefined;
+        }
+
+        try {
+            return JSON.parse(value);
+        } catch (error) {
+            return undefined;
+        }
+    }
+
+    filterOutDuplicateMessages(messages) {
+        if (!Array.isArray(messages) || !messages.length) {
+            return [];
+        }
+
+        const seen = new Set(
+            this.messages.map((message) => `${message.role}|${message.content}`)
+        );
+
+        const deduped = [];
+
+        messages.forEach((message) => {
+            if (!message || typeof message.content !== 'string') {
+                return;
+            }
+
+            const key = `${message.role}|${message.content}`;
+            if (seen.has(key)) {
+                return;
+            }
+
+            seen.add(key);
+            deduped.push(message);
+        });
+
+        return deduped;
     }
 
     buildAgentResponses(response) {

--- a/force-app/main/default/lwc/purchaseHistory/__tests__/purchaseHistory.test.js
+++ b/force-app/main/default/lwc/purchaseHistory/__tests__/purchaseHistory.test.js
@@ -5,13 +5,37 @@ jest.mock(
   "c/agentforceChat",
   () => {
     const { LightningElement } = require("lwc");
+    const initializeConversationMock = jest.fn().mockResolvedValue();
+    const prefillDraftMessageMock = jest.fn();
+    const focusComposerMock = jest.fn();
     return {
       __esModule: true,
-      default: class AgentforceChatStub extends LightningElement {}
+      initializeConversationMock,
+      prefillDraftMessageMock,
+      focusComposerMock,
+      default: class AgentforceChatStub extends LightningElement {
+        initializeConversation(...args) {
+          return initializeConversationMock(...args);
+        }
+
+        prefillDraftMessage(...args) {
+          return prefillDraftMessageMock(...args);
+        }
+
+        focusComposer(...args) {
+          return focusComposerMock(...args);
+        }
+      }
     };
   },
   { virtual: true }
 );
+
+const {
+  initializeConversationMock,
+  prefillDraftMessageMock,
+  focusComposerMock
+} = require("c/agentforceChat");
 
 jest.mock(
   "@salesforce/apex/PurchaseHistoryController.getPurchaseHistory",
@@ -31,7 +55,7 @@ describe("c-purchase-history", () => {
     jest.useRealTimers();
   });
 
-  it("opens Agentforce chat and sends the order number when the button is clicked", async () => {
+  it("opens Agentforce chat and prefills the order number when the button is clicked", async () => {
     jest.useFakeTimers();
     const element = createElement("c-purchase-history", {
       is: PurchaseHistory
@@ -77,6 +101,10 @@ describe("c-purchase-history", () => {
 
     const chatComponent = element.shadowRoot.querySelector("c-agentforce-chat");
     expect(chatComponent).not.toBeNull();
+
+    expect(initializeConversationMock).toHaveBeenCalledTimes(1);
+    expect(prefillDraftMessageMock).toHaveBeenCalledWith("00012345");
+    expect(focusComposerMock).toHaveBeenCalled();
   });
 
   it("shows an error toast when the order number is missing", async () => {

--- a/force-app/main/default/lwc/purchaseHistory/purchaseHistory.js
+++ b/force-app/main/default/lwc/purchaseHistory/purchaseHistory.js
@@ -110,10 +110,10 @@ export default class PurchaseHistory extends LightningElement {
       if (!this.isAgentforceChatSessionReady) {
         await this.delay(this.chatLaunchDelay);
         this.isAgentforceChatSessionReady = true;
-        await this.waitForRender();
       }
 
-      await this.sendOrderNumberToAgentforceChat(orderNumber);
+      await this.waitForRender();
+      await this.prepareAgentforceChat(orderNumber);
     } finally {
       this.isAgentforceChatStarting = false;
       await this.waitForRender();
@@ -143,18 +143,37 @@ export default class PurchaseHistory extends LightningElement {
     });
   }
 
-  async sendOrderNumberToAgentforceChat(orderNumber) {
-    if (!orderNumber) {
+  async prepareAgentforceChat(orderNumber) {
+    const chat = this.template.querySelector("c-agentforce-chat");
+    if (!chat) {
       return;
     }
 
     try {
-      const chat = this.template.querySelector("c-agentforce-chat");
-      if (chat && typeof chat.sendMessage === "function") {
-        await chat.sendMessage(orderNumber);
+      if (typeof chat.initializeConversation === "function") {
+        await chat.initializeConversation();
       }
     } catch (error) {
-      console.error("Failed to send message to Agentforce chat", error);
+      console.error("Failed to initialize Agentforce chat session", error);
+    }
+
+    const normalizedOrderNumber =
+      orderNumber === null || orderNumber === undefined
+        ? ""
+        : String(orderNumber);
+
+    try {
+      if (typeof chat.prefillDraftMessage === "function") {
+        chat.prefillDraftMessage(normalizedOrderNumber);
+      } else if ("draftMessage" in chat) {
+        chat.draftMessage = normalizedOrderNumber;
+      }
+
+      if (typeof chat.focusComposer === "function") {
+        chat.focusComposer();
+      }
+    } catch (error) {
+      console.error("Failed to prepare Agentforce chat composer", error);
     }
   }
 


### PR DESCRIPTION
## Summary
- surface Agentforce start session notice messages in the chat transcript and expose APIs to initialize and prefill the composer
- update the purchase history launcher to initialize the chat session, prefill the order number, and focus the composer instead of sending immediately
- extend unit tests to cover the new chat initialization behavior and composer prefill API

## Testing
- npm test *(fails: sfdx-lwc-jest not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f9908f74cc832ca876254faf2da03f