### PR TITLE
Expose return eligibility services for dedicated flows

### DIFF
--- a/force-app/main/default/classes/ReturnEligibilityService.cls
+++ b/force-app/main/default/classes/ReturnEligibilityService.cls
@@ -20,6 +20,36 @@ public with sharing class ReturnEligibilityService {
     @InvocableVariable
     public Boolean productFound;
 
+    // 対象商品のID。後続のフローで商品情報を参照する際に利用します。
+    @AuraEnabled
+    @InvocableVariable
+    public Id productId;
+
+    // 対象商品の名称です。
+    @AuraEnabled
+    @InvocableVariable
+    public String productName;
+
+    // 対象商品の商品コード／SKUです。
+    @AuraEnabled
+    @InvocableVariable
+    public String productCode;
+
+    // 対象商品の製品ファミリーです。
+    @AuraEnabled
+    @InvocableVariable
+    public String productFamily;
+
+    // 対象商品の説明文です。
+    @AuraEnabled
+    @InvocableVariable
+    public String productDescription;
+
+    // 標準価格表に登録されている単価です。
+    @AuraEnabled
+    @InvocableVariable
+    public Decimal productUnitPrice;
+
     // 続行前に顧客へ返品理由の確認が必要かどうかを示します。
     @AuraEnabled
     @InvocableVariable
@@ -44,6 +74,16 @@ public with sharing class ReturnEligibilityService {
     @AuraEnabled
     @InvocableVariable
     public String policyName;
+
+    // 適用された店舗ポリシーのIDです。
+    @AuraEnabled
+    @InvocableVariable
+    public Id policyId;
+
+    // 商品別ポリシー設定のIDです。
+    @AuraEnabled
+    @InvocableVariable
+    public Id policyProductId;
 
     // 適用されたポリシーの種別（標準・キャンペーンなど）を示します。
     @AuraEnabled
@@ -126,24 +166,6 @@ public with sharing class ReturnEligibilityService {
     public String description;
   }
 
-  private enum ReturnReasonCategory {
-    DEFECTIVE,
-    SIZE_FIT,
-    APPEARANCE,
-    UNWANTED,
-    OTHER
-  }
-
-  private static final Set<ReturnReasonCategory> ALL_REASON_CATEGORIES = new Set<ReturnReasonCategory>(
-    ReturnReasonCategory.values()
-  );
-
-  private static final Map<ReturnReasonCategory, String> CATEGORY_LABELS = buildReasonCategoryLabels();
-
-  private static final Map<String, ReturnReasonCategory> LABEL_TO_CATEGORY = buildLabelToReasonCategoryMap();
-
-  private static final Map<String, Set<ReturnReasonCategory>> POLICY_REASON_MAP = buildPolicyReasonMap();
-
   @AuraEnabled
   public static EvaluationResult evaluateProductReturn(
     String productIdentifier,
@@ -169,711 +191,32 @@ public with sharing class ReturnEligibilityService {
     return results;
   }
 
-  private class EvaluationContext {
-    String productIdentifier;
-    String returnReason;
-    Product2 product;
-    StorePolicyProduct__c policyProduct;
-    StorePolicy__c policy;
-    ReturnReasonCategory reasonCategory;
-  }
-
   private static EvaluationResult handleEvaluation(
     String productIdentifier,
     String returnReason
   ) {
-    EvaluationContext context = buildContext(productIdentifier, returnReason);
-    EvaluationResult result = initializeResult();
+    ReturnProductEligibilityService.ProductEvaluation productEvaluation = ReturnProductEligibilityService.evaluate(
+      productIdentifier
+    );
 
-    if (!validateIdentifier(context, result)) {
+    if (productEvaluation == null) {
+      return new EvaluationResult();
+    }
+
+    EvaluationResult result = productEvaluation.result;
+    if (result == null) {
+      result = new EvaluationResult();
+    }
+
+    if (!Boolean.TRUE.equals(productEvaluation.canProceed)) {
       return result;
     }
 
-    if (!resolveProduct(context, result)) {
-      return result;
-    }
-
-    if (!resolvePolicy(context, result)) {
-      return result;
-    }
-
-    if (!validatePolicyAllowsReturn(context, result)) {
-      return result;
-    }
-
-    if (!ensureReasonProvided(context, result)) {
-      return result;
-    }
-
-    if (!assignReasonCategory(context, result)) {
-      return result;
-    }
-
-    if (!validateReasonAgainstPolicy(context, result)) {
-      return result;
-    }
-
-    markReturnApproved(result);
-    return result;
-  }
-
-  private static EvaluationContext buildContext(
-    String productIdentifier,
-    String returnReason
-  ) {
-    EvaluationContext context = new EvaluationContext();
-    context.productIdentifier = productIdentifier != null
-      ? productIdentifier.trim()
-      : null;
-    context.returnReason = returnReason != null ? returnReason.trim() : null;
-    return context;
-  }
-
-  private static EvaluationResult initializeResult() {
-    EvaluationResult result = new EvaluationResult();
-    result.productFound = false;
-    result.isReturnable = false;
-    result.reasonAccepted = false;
-    result.requiresReason = false;
-    result.status = 'UNRESOLVED';
-    return result;
-  }
-
-  private static Boolean validateIdentifier(
-    EvaluationContext context,
-    EvaluationResult result
-  ) {
-    if (String.isBlank(context.productIdentifier)) {
-      result.primaryMessage = '商品名または商品コードを入力してください。';
-      result.status = 'MISSING_IDENTIFIER';
-      return false;
-    }
-    return true;
-  }
-
-  private static Boolean resolveProduct(
-    EvaluationContext context,
-    EvaluationResult result
-  ) {
-    context.product = findProduct(context.productIdentifier);
-    if (context.product == null) {
-      result.primaryMessage = '該当する商品が見つかりませんでした。商品名または商品コードをご確認ください。';
-      result.status = 'PRODUCT_NOT_FOUND';
-      return false;
-    }
-
-    result.productFound = true;
-    return true;
-  }
-
-  private static Boolean resolvePolicy(
-    EvaluationContext context,
-    EvaluationResult result
-  ) {
-    context.policyProduct = findPolicyForProduct(context.product.Id);
-    if (
-      context.policyProduct == null ||
-      context.policyProduct.StorePolicy__r == null
-    ) {
-      applyPolicyNotFoundState(result, context.product);
-      return false;
-    }
-
-    context.policy = context.policyProduct.StorePolicy__r;
-    result.policyName = context.policy.Name;
-    result.policyType = context.policy.PolicyType__c;
-    result.policyDescription = context.policy.Description__c;
-    return true;
-  }
-
-  private static Boolean validatePolicyAllowsReturn(
-    EvaluationContext context,
-    EvaluationResult result
-  ) {
-    if (
-      isPolicyCurrentlyAllowingReturn(context.policyProduct, context.policy)
-    ) {
-      return true;
-    }
-
-    applyReturnNotAllowedState(
+    return ReturnReasonEvaluationService.evaluate(
+      returnReason,
+      productEvaluation.policy,
       result,
-      context.product,
-      getProductUnitPrice(context.product)
+      productEvaluation.product
     );
-    result.status = 'RETURN_NOT_ALLOWED';
-    return false;
-  }
-
-  private static Boolean ensureReasonProvided(
-    EvaluationContext context,
-    EvaluationResult result
-  ) {
-    if (!String.isBlank(context.returnReason)) {
-      return true;
-    }
-
-    result.primaryMessage = '返品理由をお聞かせください。';
-    result.isReturnable = true;
-    result.requiresReason = true;
-    result.status = 'ASK_REASON';
-    return false;
-  }
-
-  private static Boolean assignReasonCategory(
-    EvaluationContext context,
-    EvaluationResult result
-  ) {
-    context.reasonCategory = resolveReasonCategory(context.returnReason);
-    if (context.reasonCategory == null) {
-      result.primaryMessage = '入力された返品理由を認識できません。もう一度ご入力ください。';
-      result.requiresReason = true;
-      result.status = 'INVALID_REASON_CATEGORY';
-      result.reasonCategory = context.returnReason;
-      return false;
-    }
-
-    result.reasonCategory = CATEGORY_LABELS.get(context.reasonCategory);
-    return true;
-  }
-
-  private static Boolean validateReasonAgainstPolicy(
-    EvaluationContext context,
-    EvaluationResult result
-  ) {
-    if (
-      isReasonAllowedByPolicy(
-        context.policy != null ? context.policy.PolicyType__c : null,
-        context.reasonCategory
-      )
-    ) {
-      return true;
-    }
-
-    applyReturnNotAllowedState(
-      result,
-      context.product,
-      getProductUnitPrice(context.product)
-    );
-    result.status = 'RETURN_REJECTED_REASON';
-    return false;
-  }
-
-  private static void markReturnApproved(EvaluationResult result) {
-    result.isReturnable = true;
-    result.reasonAccepted = true;
-    result.primaryMessage = 'ご迷惑をおかけし、誠に申し訳ございません。すぐに新しい商品をお送りいたしますが、よろしいでしょうか？';
-    result.status = 'RETURN_APPROVED';
-  }
-
-  private static void applyPolicyNotFoundState(
-    EvaluationResult result,
-    Product2 product
-  ) {
-    result.primaryMessage = '申し訳ございません。この商品の返品ポリシー情報が見つかりませんでした。';
-    result.secondaryMessage = '代わりに交換はいかがでしょうか？';
-    populateExchangeOptions(result, product, null);
-    result.status = 'POLICY_NOT_FOUND';
-  }
-
-  private static void applyReturnNotAllowedState(
-    EvaluationResult result,
-    Product2 product,
-    Decimal basePrice
-  ) {
-    result.primaryMessage = '申し訳ございませんが、この商品の返品はポリシーによりお受けできません。';
-    result.secondaryMessage = '代わりに交換はいかがでしょうか？';
-    populateExchangeOptions(result, product, basePrice);
-  }
-
-  private static void populateExchangeOptions(
-    EvaluationResult result,
-    Product2 product,
-    Decimal basePrice
-  ) {
-    result.exchangeOptions = findExchangeOptions(product);
-    if (!result.exchangeOptions.isEmpty()) {
-      result.exchangeMessage = '在庫がございます。サイズ／色違いの商品をお送りできますが、よろしいでしょうか？';
-      if (result.alternativeProducts == null) {
-        result.alternativeProducts = new List<ProductSuggestion>();
-      } else {
-        result.alternativeProducts.clear();
-      }
-      result.alternativeMessage = null;
-      return;
-    }
-
-    result.exchangeMessage = '申し訳ございません。現在交換用の在庫がございませんが、似たタイプの別商品をおすすめできます。';
-    result.alternativeProducts = findAlternativeProducts(product, basePrice);
-    if (!result.alternativeProducts.isEmpty()) {
-      result.alternativeMessage = buildAlternativesMessage(
-        result.alternativeProducts
-      );
-    } else {
-      result.alternativeMessage = null;
-    }
-  }
-
-  private static Product2 findProduct(String productIdentifier) {
-    List<Product2> matches = [
-      SELECT Id, Name, ProductCode, Family, Description, IsActive
-      FROM Product2
-      WHERE
-        (ProductCode = :productIdentifier
-        OR Name = :productIdentifier)
-        AND IsActive = TRUE
-      LIMIT 1
-    ];
-
-    if (!matches.isEmpty()) {
-      return matches[0];
-    }
-
-    matches = [
-      SELECT Id, Name, ProductCode, Family, Description, IsActive
-      FROM Product2
-      WHERE
-        (ProductCode LIKE :('%' + productIdentifier + '%')
-        OR Name LIKE :('%' + productIdentifier + '%'))
-        AND IsActive = TRUE
-      ORDER BY CreatedDate DESC
-      LIMIT 1
-    ];
-
-    return matches.isEmpty() ? null : matches[0];
-  }
-
-  private static StorePolicyProduct__c findPolicyForProduct(Id productId) {
-    List<StorePolicyProduct__c> policies = [
-      SELECT
-        Id,
-        Product__c,
-        StorePolicy__c,
-        IsActive__c,
-        Remarks__c,
-        StorePolicy__r.Id,
-        StorePolicy__r.Name,
-        StorePolicy__r.PolicyType__c,
-        StorePolicy__r.IsActive__c,
-        StorePolicy__r.ValidFrom__c,
-        StorePolicy__r.ValidTo__c,
-        StorePolicy__r.Description__c
-      FROM StorePolicyProduct__c
-      WHERE Product__c = :productId
-      LIMIT 1
-    ];
-    return policies.isEmpty() ? null : policies[0];
-  }
-
-  private static Boolean isPolicyCurrentlyAllowingReturn(
-    StorePolicyProduct__c policyProduct,
-    StorePolicy__c policy
-  ) {
-    if (policyProduct == null || policy == null) {
-      return false;
-    }
-
-    if (!(policyProduct.IsActive__c == true && policy.IsActive__c == true)) {
-      return false;
-    }
-
-    Date today = System.today();
-    if (
-      (policy.ValidFrom__c != null && policy.ValidFrom__c > today) ||
-      (policy.ValidTo__c != null &&
-      policy.ValidTo__c < today)
-    ) {
-      return false;
-    }
-
-    return true;
-  }
-
-  private static Boolean isReasonAllowedByPolicy(
-    String policyType,
-    ReturnReasonCategory category
-  ) {
-    if (category == null) {
-      return false;
-    }
-
-    if (String.isBlank(policyType)) {
-      return category != ReturnReasonCategory.OTHER;
-    }
-
-    String key = policyType.trim().toUpperCase();
-    if (POLICY_REASON_MAP.containsKey(key)) {
-      Set<ReturnReasonCategory> allowed = POLICY_REASON_MAP.get(key);
-      return allowed != null && allowed.contains(category);
-    }
-
-    return false;
-  }
-
-  private static ReturnReasonCategory resolveReasonCategory(
-    String reasonValue
-  ) {
-    if (String.isBlank(reasonValue)) {
-      return null;
-    }
-
-    String candidate = extractCategoryToken(reasonValue);
-    if (String.isBlank(candidate)) {
-      return null;
-    }
-
-    String normalized = candidate.replace('-', '_')
-      .replace(' ', '_')
-      .toUpperCase();
-    try {
-      return ReturnReasonCategory.valueOf(normalized);
-    } catch (Exception ex) {
-      if (LABEL_TO_CATEGORY.containsKey(candidate)) {
-        return LABEL_TO_CATEGORY.get(candidate);
-      }
-      return null;
-    }
-  }
-
-  private static String extractCategoryToken(String rawValue) {
-    if (String.isBlank(rawValue)) {
-      return null;
-    }
-
-    String trimmed = rawValue.trim();
-    if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
-      try {
-        Map<String, Object> payload = (Map<String, Object>) JSON.deserializeUntyped(
-          trimmed
-        );
-        if (payload != null) {
-          Object categoryValue = payload.get('category');
-          if (categoryValue instanceof String) {
-            String categoryString = ((String) categoryValue).trim();
-            if (!String.isBlank(categoryString)) {
-              return categoryString;
-            }
-          }
-        }
-      } catch (Exception ex) {
-        // フォールバックとして JSON 文字列全体を後続の処理へ渡します。
-      }
-    }
-
-    return trimmed;
-  }
-
-  private static Map<ReturnReasonCategory, String> buildReasonCategoryLabels() {
-    Map<ReturnReasonCategory, String> labels = new Map<ReturnReasonCategory, String>();
-    labels.put(ReturnReasonCategory.DEFECTIVE, '不良・破損');
-    labels.put(ReturnReasonCategory.SIZE_FIT, 'サイズが合わない');
-    labels.put(ReturnReasonCategory.APPEARANCE, 'イメージと違う');
-    labels.put(ReturnReasonCategory.UNWANTED, '不要になった');
-    labels.put(ReturnReasonCategory.OTHER, 'その他');
-    return labels;
-  }
-
-  private static Map<String, ReturnReasonCategory> buildLabelToReasonCategoryMap() {
-    Map<String, ReturnReasonCategory> mapping = new Map<String, ReturnReasonCategory>();
-    for (ReturnReasonCategory category : ReturnReasonCategory.values()) {
-      String label = CATEGORY_LABELS.get(category);
-      if (!String.isBlank(label)) {
-        mapping.put(label, category);
-      }
-    }
-    return mapping;
-  }
-
-  private static Map<String, Set<ReturnReasonCategory>> buildPolicyReasonMap() {
-    Map<String, Set<ReturnReasonCategory>> mapping = new Map<String, Set<ReturnReasonCategory>>();
-    mapping.put(
-      'RETURN_ALL',
-      new Set<ReturnReasonCategory>(ALL_REASON_CATEGORIES)
-    );
-    mapping.put(
-      'RETURN_DEFECTIVE_ONLY',
-      new Set<ReturnReasonCategory>{ ReturnReasonCategory.DEFECTIVE }
-    );
-    mapping.put(
-      'RETURN_DEFECTIVE_SIZE',
-      new Set<ReturnReasonCategory>{
-        ReturnReasonCategory.DEFECTIVE,
-        ReturnReasonCategory.SIZE_FIT
-      }
-    );
-    mapping.put(
-      'RETURN_SIZE_ONLY',
-      new Set<ReturnReasonCategory>{ ReturnReasonCategory.SIZE_FIT }
-    );
-    mapping.put(
-      'RETURN_APPEARANCE',
-      new Set<ReturnReasonCategory>{ ReturnReasonCategory.APPEARANCE }
-    );
-    mapping.put(
-      'RETURN_SATISFACTION',
-      new Set<ReturnReasonCategory>{
-        ReturnReasonCategory.APPEARANCE,
-        ReturnReasonCategory.UNWANTED
-      }
-    );
-    mapping.put(
-      'RETURN_UNWANTED',
-      new Set<ReturnReasonCategory>{ ReturnReasonCategory.UNWANTED }
-    );
-    mapping.put(
-      'RETURN_OTHER',
-      new Set<ReturnReasonCategory>{ ReturnReasonCategory.OTHER }
-    );
-    mapping.put(
-      'RETURN_DEFECTIVE_APPEARANCE',
-      new Set<ReturnReasonCategory>{
-        ReturnReasonCategory.DEFECTIVE,
-        ReturnReasonCategory.APPEARANCE
-      }
-    );
-    mapping.put(
-      'RETURN_DEFECTIVE_SATISFACTION',
-      new Set<ReturnReasonCategory>{
-        ReturnReasonCategory.DEFECTIVE,
-        ReturnReasonCategory.APPEARANCE,
-        ReturnReasonCategory.UNWANTED
-      }
-    );
-    return mapping;
-  }
-
-  private static List<ProductSuggestion> findExchangeOptions(Product2 product) {
-    if (product == null) {
-      return new List<ProductSuggestion>();
-    }
-
-    String family = product.Family;
-    String baseName = product.Name;
-    String baseCode = product.ProductCode;
-
-    String normalizedName = null;
-    if (!String.isBlank(baseName)) {
-      Integer hyphenIndex = baseName.indexOf('-');
-      if (hyphenIndex > 0) {
-        normalizedName = baseName.substring(0, hyphenIndex).trim();
-      } else {
-        normalizedName = baseName.trim();
-      }
-    }
-    String namePattern = normalizedName != null
-      ? '%' + normalizedName + '%'
-      : null;
-    String normalizedLower = normalizedName != null
-      ? normalizedName.toLowerCase()
-      : null;
-    String baseCodeLower = !String.isBlank(baseCode)
-      ? baseCode.toLowerCase()
-      : null;
-
-    List<Product2> rawVariations = new List<Product2>();
-    if (!String.isBlank(family)) {
-      rawVariations = [
-        SELECT Id, Name, ProductCode, Family, Description
-        FROM Product2
-        WHERE IsActive = TRUE AND Id != :product.Id AND Family = :family
-        ORDER BY CreatedDate DESC
-        LIMIT 25
-      ];
-    }
-
-    List<Product2> variationCandidates = new List<Product2>();
-    if (!rawVariations.isEmpty()) {
-      for (Product2 candidate : rawVariations) {
-        if (variationCandidates.size() >= 5) {
-          break;
-        }
-        Boolean matches = false;
-        if (
-          normalizedLower != null &&
-          candidate.Name != null &&
-          candidate.Name.toLowerCase().contains(normalizedLower)
-        ) {
-          matches = true;
-        }
-        if (
-          !matches &&
-          baseCodeLower != null &&
-          candidate.ProductCode != null &&
-          candidate.ProductCode.toLowerCase().startsWith(baseCodeLower)
-        ) {
-          matches = true;
-        }
-        if (!matches && normalizedLower == null && baseCodeLower == null) {
-          matches = true;
-        }
-        if (matches) {
-          variationCandidates.add(candidate);
-        }
-      }
-    }
-
-    if (variationCandidates.isEmpty() && !String.isBlank(normalizedName)) {
-      rawVariations = [
-        SELECT Id, Name, ProductCode, Family, Description
-        FROM Product2
-        WHERE IsActive = TRUE AND Id != :product.Id AND Name LIKE :namePattern
-        ORDER BY CreatedDate DESC
-        LIMIT 5
-      ];
-      variationCandidates.addAll(rawVariations);
-    }
-
-    List<ProductSuggestion> suggestions = new List<ProductSuggestion>();
-    for (Product2 variation : variationCandidates) {
-      ProductSuggestion suggestion = new ProductSuggestion();
-      suggestion.productId = variation.Id;
-      suggestion.name = variation.Name;
-      suggestion.productCode = variation.ProductCode;
-      suggestion.family = variation.Family;
-      suggestion.description = variation.Description;
-      suggestion.unitPrice = getProductUnitPrice(variation);
-      suggestions.add(suggestion);
-    }
-
-    return suggestions;
-  }
-
-  private static List<ProductSuggestion> findAlternativeProducts(
-    Product2 product,
-    Decimal basePrice
-  ) {
-    if (product == null) {
-      return new List<ProductSuggestion>();
-    }
-
-    Id standardPricebookId = getStandardPricebookIdSafe();
-    Decimal comparisonPrice = basePrice != null
-      ? basePrice
-      : getProductUnitPrice(product);
-
-    String family = product.Family;
-    List<ProductSuggestion> alternatives = new List<ProductSuggestion>();
-    if (String.isBlank(family)) {
-      return alternatives;
-    }
-
-    if (comparisonPrice != null && standardPricebookId != null) {
-      Decimal tolerance = comparisonPrice * 0.2;
-      Decimal minPrice = comparisonPrice - tolerance;
-      Decimal maxPrice = comparisonPrice + tolerance;
-      List<PricebookEntry> entries = [
-        SELECT
-          Id,
-          Product2.Id,
-          Product2.Name,
-          Product2.ProductCode,
-          Product2.Family,
-          Product2.Description,
-          UnitPrice
-        FROM PricebookEntry
-        WHERE
-          Pricebook2Id = :standardPricebookId
-          AND Product2.IsActive = TRUE
-          AND Product2Id != :product.Id
-          AND Product2.Family = :family
-          AND UnitPrice >= :minPrice
-          AND UnitPrice <= :maxPrice
-        ORDER BY UnitPrice ASC
-        LIMIT 5
-      ];
-      for (PricebookEntry entry : entries) {
-        ProductSuggestion suggestion = new ProductSuggestion();
-        suggestion.productId = entry.Product2Id;
-        suggestion.name = entry.Product2.Name;
-        suggestion.productCode = entry.Product2.ProductCode;
-        suggestion.family = entry.Product2.Family;
-        suggestion.description = entry.Product2.Description;
-        suggestion.unitPrice = entry.UnitPrice;
-        alternatives.add(suggestion);
-      }
-    }
-
-    if (alternatives.isEmpty()) {
-      List<Product2> familyProducts = [
-        SELECT Id, Name, ProductCode, Family, Description
-        FROM Product2
-        WHERE IsActive = TRUE AND Family = :family AND Id != :product.Id
-        ORDER BY CreatedDate DESC
-        LIMIT 5
-      ];
-      for (Product2 familyProduct : familyProducts) {
-        ProductSuggestion suggestion = new ProductSuggestion();
-        suggestion.productId = familyProduct.Id;
-        suggestion.name = familyProduct.Name;
-        suggestion.productCode = familyProduct.ProductCode;
-        suggestion.family = familyProduct.Family;
-        suggestion.description = familyProduct.Description;
-        suggestion.unitPrice = getProductUnitPrice(familyProduct);
-        alternatives.add(suggestion);
-      }
-    }
-
-    return alternatives;
-  }
-
-  private static String buildAlternativesMessage(
-    List<ProductSuggestion> suggestions
-  ) {
-    if (suggestions == null || suggestions.isEmpty()) {
-      return null;
-    }
-    List<String> parts = new List<String>();
-    for (ProductSuggestion suggestion : suggestions) {
-      List<String> fragments = new List<String>();
-      if (!String.isBlank(suggestion.name)) {
-        fragments.add(suggestion.name);
-      }
-      if (!String.isBlank(suggestion.productCode)) {
-        fragments.add('商品コード: ' + suggestion.productCode);
-      }
-      if (suggestion.unitPrice != null) {
-        fragments.add(
-          '価格: ¥' + String.valueOf(Math.round(suggestion.unitPrice))
-        );
-      }
-      parts.add(String.join(fragments, ' / '));
-    }
-    return '代替候補: ' + String.join(parts, '、 ');
-  }
-
-  private static Decimal getProductUnitPrice(Product2 product) {
-    Id standardPricebookId = getStandardPricebookIdSafe();
-    if (product == null || standardPricebookId == null) {
-      return null;
-    }
-
-    List<PricebookEntry> entries = [
-      SELECT UnitPrice
-      FROM PricebookEntry
-      WHERE
-        Pricebook2Id = :standardPricebookId
-        AND Product2Id = :product.Id
-        AND IsActive = TRUE
-      LIMIT 1
-    ];
-    return entries.isEmpty() ? null : entries[0].UnitPrice;
-  }
-
-  private static Id getStandardPricebookIdSafe() {
-    try {
-      if (Test.isRunningTest()) {
-        return Test.getStandardPricebookId();
-      }
-
-      List<Pricebook2> standard = [
-        SELECT Id
-        FROM Pricebook2
-        WHERE IsStandard = TRUE
-        LIMIT 1
-      ];
-      return standard.isEmpty() ? null : standard[0].Id;
-    } catch (Exception ex) {
-      return null;
-    }
   }
 }

--- a/force-app/main/default/classes/ReturnProductEligibilityService.cls
+++ b/force-app/main/default/classes/ReturnProductEligibilityService.cls
@@ -1,0 +1,496 @@
+public with sharing class ReturnProductEligibilityService {
+  public class ProductEvaluation {
+    public ReturnEligibilityService.EvaluationResult result;
+    public Boolean canProceed;
+    public Product2 product;
+    public StorePolicyProduct__c policyProduct;
+    public StorePolicy__c policy;
+  }
+
+  public class ProductEvaluationInput {
+    @InvocableVariable(required=true)
+    public String productIdentifier;
+  }
+
+  @InvocableMethod(
+    label='返品対象商品の判定',
+    description='商品情報に基づき返品ポリシーを確認し、理由判定フローへ渡すための情報を返します。'
+  )
+  public static List<ReturnEligibilityService.EvaluationResult> evaluateForFlow(
+    List<ProductEvaluationInput> inputs
+  ) {
+    List<ReturnEligibilityService.EvaluationResult> results = new List<ReturnEligibilityService.EvaluationResult>();
+    if (inputs == null) {
+      return results;
+    }
+
+    for (ProductEvaluationInput input : inputs) {
+      ProductEvaluation evaluation = evaluate(
+        input != null ? input.productIdentifier : null
+      );
+      ReturnEligibilityService.EvaluationResult result = evaluation != null &&
+        evaluation.result != null
+        ? evaluation.result
+        : new ReturnEligibilityService.EvaluationResult();
+      results.add(result);
+    }
+
+    return results;
+  }
+
+  public static ProductEvaluation evaluate(String productIdentifier) {
+    ProductEvaluation evaluation = new ProductEvaluation();
+    evaluation.result = initializeResult();
+    evaluation.canProceed = false;
+
+    String normalizedIdentifier = productIdentifier != null
+      ? productIdentifier.trim()
+      : null;
+    if (!validateIdentifier(normalizedIdentifier, evaluation.result)) {
+      return evaluation;
+    }
+
+    evaluation.product = findProduct(normalizedIdentifier);
+    if (evaluation.product == null) {
+      evaluation.result.primaryMessage = '該当する商品が見つかりませんでした。商品名または商品コードをご確認ください。';
+      evaluation.result.status = 'PRODUCT_NOT_FOUND';
+      return evaluation;
+    }
+
+    evaluation.result.productFound = true;
+    evaluation.result.productId = evaluation.product.Id;
+    evaluation.result.productName = evaluation.product.Name;
+    evaluation.result.productCode = evaluation.product.ProductCode;
+    evaluation.result.productFamily = evaluation.product.Family;
+    evaluation.result.productDescription = evaluation.product.Description;
+    evaluation.result.productUnitPrice = getProductUnitPrice(
+      evaluation.product
+    );
+
+    evaluation.policyProduct = findPolicyForProduct(evaluation.product.Id);
+    if (
+      evaluation.policyProduct == null ||
+      evaluation.policyProduct.StorePolicy__r == null
+    ) {
+      applyPolicyNotFoundState(evaluation.result, evaluation.product);
+      evaluation.result.status = 'POLICY_NOT_FOUND';
+      return evaluation;
+    }
+
+    evaluation.policy = evaluation.policyProduct.StorePolicy__r;
+    evaluation.result.policyProductId = evaluation.policyProduct.Id;
+    evaluation.result.policyId = evaluation.policy.Id;
+    evaluation.result.policyName = evaluation.policy.Name;
+    evaluation.result.policyType = evaluation.policy.PolicyType__c;
+    evaluation.result.policyDescription = evaluation.policy.Description__c;
+
+    if (
+      !isPolicyCurrentlyAllowingReturn(
+        evaluation.policyProduct,
+        evaluation.policy
+      )
+    ) {
+      applyReturnDenied(evaluation.result, evaluation.product);
+      evaluation.result.status = 'RETURN_NOT_ALLOWED';
+      return evaluation;
+    }
+
+    evaluation.canProceed = true;
+    evaluation.result.isReturnable = true;
+    evaluation.result.requiresReason = true;
+    evaluation.result.reasonAccepted = false;
+    evaluation.result.status = 'AWAITING_REASON';
+    evaluation.result.primaryMessage = '返品理由をお聞かせください。';
+    evaluation.result.secondaryMessage = '該当する理由カテゴリを選択してください。';
+    evaluation.result.availableReasonCategories = ReturnReasonEvaluationService.getAvailableReasonLabels();
+    return evaluation;
+  }
+
+  public static void applyReturnDenied(
+    ReturnEligibilityService.EvaluationResult result,
+    Product2 product
+  ) {
+    applyReturnNotAllowedState(result, product, getProductUnitPrice(product));
+  }
+
+  private static ReturnEligibilityService.EvaluationResult initializeResult() {
+    ReturnEligibilityService.EvaluationResult result = new ReturnEligibilityService.EvaluationResult();
+    result.productFound = false;
+    result.isReturnable = false;
+    result.reasonAccepted = false;
+    result.requiresReason = false;
+    result.status = 'UNRESOLVED';
+    return result;
+  }
+
+  private static Boolean validateIdentifier(
+    String productIdentifier,
+    ReturnEligibilityService.EvaluationResult result
+  ) {
+    if (String.isBlank(productIdentifier)) {
+      result.primaryMessage = '商品名または商品コードを入力してください。';
+      result.status = 'MISSING_IDENTIFIER';
+      return false;
+    }
+    return true;
+  }
+
+  private static Product2 findProduct(String productIdentifier) {
+    List<Product2> matches = [
+      SELECT Id, Name, ProductCode, Family, Description, IsActive
+      FROM Product2
+      WHERE
+        (ProductCode = :productIdentifier
+        OR Name = :productIdentifier)
+        AND IsActive = TRUE
+      LIMIT 1
+    ];
+
+    if (!matches.isEmpty()) {
+      return matches[0];
+    }
+
+    matches = [
+      SELECT Id, Name, ProductCode, Family, Description, IsActive
+      FROM Product2
+      WHERE
+        (ProductCode LIKE :('%' + productIdentifier + '%')
+        OR Name LIKE :('%' + productIdentifier + '%'))
+        AND IsActive = TRUE
+      ORDER BY CreatedDate DESC
+      LIMIT 1
+    ];
+
+    return matches.isEmpty() ? null : matches[0];
+  }
+
+  private static StorePolicyProduct__c findPolicyForProduct(Id productId) {
+    List<StorePolicyProduct__c> policies = [
+      SELECT
+        Id,
+        Product__c,
+        StorePolicy__c,
+        IsActive__c,
+        Remarks__c,
+        StorePolicy__r.Id,
+        StorePolicy__r.Name,
+        StorePolicy__r.PolicyType__c,
+        StorePolicy__r.IsActive__c,
+        StorePolicy__r.ValidFrom__c,
+        StorePolicy__r.ValidTo__c,
+        StorePolicy__r.Description__c
+      FROM StorePolicyProduct__c
+      WHERE Product__c = :productId
+      LIMIT 1
+    ];
+    return policies.isEmpty() ? null : policies[0];
+  }
+
+  private static Boolean isPolicyCurrentlyAllowingReturn(
+    StorePolicyProduct__c policyProduct,
+    StorePolicy__c policy
+  ) {
+    if (policyProduct == null || policy == null) {
+      return false;
+    }
+
+    if (!(policyProduct.IsActive__c == true && policy.IsActive__c == true)) {
+      return false;
+    }
+
+    Date today = System.today();
+    if (
+      (policy.ValidFrom__c != null && policy.ValidFrom__c > today) ||
+      (policy.ValidTo__c != null &&
+      policy.ValidTo__c < today)
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+
+  private static void applyPolicyNotFoundState(
+    ReturnEligibilityService.EvaluationResult result,
+    Product2 product
+  ) {
+    result.primaryMessage = '申し訳ございません。この商品の返品ポリシー情報が見つかりませんでした。';
+    result.secondaryMessage = '代わりに交換はいかがでしょうか？';
+    populateExchangeOptions(result, product, null);
+  }
+
+  private static void applyReturnNotAllowedState(
+    ReturnEligibilityService.EvaluationResult result,
+    Product2 product,
+    Decimal basePrice
+  ) {
+    result.primaryMessage = '申し訳ございませんが、この商品の返品はポリシーによりお受けできません。';
+    result.secondaryMessage = '代わりに交換はいかがでしょうか？';
+    populateExchangeOptions(result, product, basePrice);
+  }
+
+  private static void populateExchangeOptions(
+    ReturnEligibilityService.EvaluationResult result,
+    Product2 product,
+    Decimal basePrice
+  ) {
+    result.exchangeOptions = findExchangeOptions(product);
+    if (!result.exchangeOptions.isEmpty()) {
+      result.exchangeMessage = '在庫がございます。サイズ／色違いの商品をお送りできますが、よろしいでしょうか？';
+      if (result.alternativeProducts == null) {
+        result.alternativeProducts = new List<ReturnEligibilityService.ProductSuggestion>();
+      } else {
+        result.alternativeProducts.clear();
+      }
+      result.alternativeMessage = null;
+      return;
+    }
+
+    result.exchangeMessage = '申し訳ございません。現在交換用の在庫がございませんが、似たタイプの別商品をおすすめできます。';
+    result.alternativeProducts = findAlternativeProducts(product, basePrice);
+    if (!result.alternativeProducts.isEmpty()) {
+      result.alternativeMessage = buildAlternativesMessage(
+        result.alternativeProducts
+      );
+    } else {
+      result.alternativeMessage = null;
+    }
+  }
+
+  private static List<ReturnEligibilityService.ProductSuggestion> findExchangeOptions(
+    Product2 product
+  ) {
+    if (product == null) {
+      return new List<ReturnEligibilityService.ProductSuggestion>();
+    }
+
+    String family = product.Family;
+    String baseName = product.Name;
+    String baseCode = product.ProductCode;
+
+    String normalizedName = null;
+    if (!String.isBlank(baseName)) {
+      Integer hyphenIndex = baseName.indexOf('-');
+      if (hyphenIndex > 0) {
+        normalizedName = baseName.substring(0, hyphenIndex).trim();
+      } else {
+        normalizedName = baseName.trim();
+      }
+    }
+    String namePattern = normalizedName != null
+      ? '%' + normalizedName + '%'
+      : null;
+    String normalizedLower = normalizedName != null
+      ? normalizedName.toLowerCase()
+      : null;
+    String baseCodeLower = !String.isBlank(baseCode)
+      ? baseCode.toLowerCase()
+      : null;
+
+    List<Product2> rawVariations = new List<Product2>();
+    if (!String.isBlank(family)) {
+      rawVariations = [
+        SELECT Id, Name, ProductCode, Family, Description
+        FROM Product2
+        WHERE IsActive = TRUE AND Id != :product.Id AND Family = :family
+        ORDER BY CreatedDate DESC
+        LIMIT 25
+      ];
+    }
+
+    List<Product2> variationCandidates = new List<Product2>();
+    if (!rawVariations.isEmpty()) {
+      for (Product2 candidate : rawVariations) {
+        if (variationCandidates.size() >= 5) {
+          break;
+        }
+        Boolean matches = false;
+        if (
+          normalizedLower != null &&
+          candidate.Name != null &&
+          candidate.Name.toLowerCase().contains(normalizedLower)
+        ) {
+          matches = true;
+        }
+        if (
+          !matches &&
+          baseCodeLower != null &&
+          candidate.ProductCode != null &&
+          candidate.ProductCode.toLowerCase().startsWith(baseCodeLower)
+        ) {
+          matches = true;
+        }
+        if (!matches && normalizedLower == null && baseCodeLower == null) {
+          matches = true;
+        }
+        if (matches) {
+          variationCandidates.add(candidate);
+        }
+      }
+    }
+
+    if (variationCandidates.isEmpty() && !String.isBlank(normalizedName)) {
+      rawVariations = [
+        SELECT Id, Name, ProductCode, Family, Description
+        FROM Product2
+        WHERE IsActive = TRUE AND Id != :product.Id AND Name LIKE :namePattern
+        ORDER BY CreatedDate DESC
+        LIMIT 5
+      ];
+      variationCandidates.addAll(rawVariations);
+    }
+
+    List<ReturnEligibilityService.ProductSuggestion> suggestions = new List<ReturnEligibilityService.ProductSuggestion>();
+    for (Product2 variation : variationCandidates) {
+      ReturnEligibilityService.ProductSuggestion suggestion = new ReturnEligibilityService.ProductSuggestion();
+      suggestion.productId = variation.Id;
+      suggestion.name = variation.Name;
+      suggestion.productCode = variation.ProductCode;
+      suggestion.family = variation.Family;
+      suggestion.description = variation.Description;
+      suggestion.unitPrice = getProductUnitPrice(variation);
+      suggestions.add(suggestion);
+    }
+
+    return suggestions;
+  }
+
+  private static List<ReturnEligibilityService.ProductSuggestion> findAlternativeProducts(
+    Product2 product,
+    Decimal basePrice
+  ) {
+    if (product == null) {
+      return new List<ReturnEligibilityService.ProductSuggestion>();
+    }
+
+    Id standardPricebookId = getStandardPricebookIdSafe();
+    Decimal comparisonPrice = basePrice != null
+      ? basePrice
+      : getProductUnitPrice(product);
+
+    String family = product.Family;
+    List<ReturnEligibilityService.ProductSuggestion> alternatives = new List<ReturnEligibilityService.ProductSuggestion>();
+    if (String.isBlank(family)) {
+      return alternatives;
+    }
+
+    if (comparisonPrice != null && standardPricebookId != null) {
+      Decimal tolerance = comparisonPrice * 0.2;
+      Decimal minPrice = comparisonPrice - tolerance;
+      Decimal maxPrice = comparisonPrice + tolerance;
+      List<PricebookEntry> entries = [
+        SELECT
+          Id,
+          Product2.Id,
+          Product2.Name,
+          Product2.ProductCode,
+          Product2.Family,
+          Product2.Description,
+          UnitPrice
+        FROM PricebookEntry
+        WHERE
+          Pricebook2Id = :standardPricebookId
+          AND Product2.IsActive = TRUE
+          AND Product2Id != :product.Id
+          AND Product2.Family = :family
+          AND UnitPrice >= :minPrice
+          AND UnitPrice <= :maxPrice
+        ORDER BY UnitPrice ASC
+        LIMIT 5
+      ];
+      for (PricebookEntry entry : entries) {
+        ReturnEligibilityService.ProductSuggestion suggestion = new ReturnEligibilityService.ProductSuggestion();
+        suggestion.productId = entry.Product2Id;
+        suggestion.name = entry.Product2.Name;
+        suggestion.productCode = entry.Product2.ProductCode;
+        suggestion.family = entry.Product2.Family;
+        suggestion.description = entry.Product2.Description;
+        suggestion.unitPrice = entry.UnitPrice;
+        alternatives.add(suggestion);
+      }
+    }
+
+    if (alternatives.isEmpty()) {
+      List<Product2> familyProducts = [
+        SELECT Id, Name, ProductCode, Family, Description
+        FROM Product2
+        WHERE IsActive = TRUE AND Family = :family AND Id != :product.Id
+        ORDER BY CreatedDate DESC
+        LIMIT 5
+      ];
+      for (Product2 familyProduct : familyProducts) {
+        ReturnEligibilityService.ProductSuggestion suggestion = new ReturnEligibilityService.ProductSuggestion();
+        suggestion.productId = familyProduct.Id;
+        suggestion.name = familyProduct.Name;
+        suggestion.productCode = familyProduct.ProductCode;
+        suggestion.family = familyProduct.Family;
+        suggestion.description = familyProduct.Description;
+        suggestion.unitPrice = getProductUnitPrice(familyProduct);
+        alternatives.add(suggestion);
+      }
+    }
+
+    return alternatives;
+  }
+
+  private static String buildAlternativesMessage(
+    List<ReturnEligibilityService.ProductSuggestion> suggestions
+  ) {
+    if (suggestions == null || suggestions.isEmpty()) {
+      return null;
+    }
+    List<String> parts = new List<String>();
+    for (ReturnEligibilityService.ProductSuggestion suggestion : suggestions) {
+      List<String> fragments = new List<String>();
+      if (!String.isBlank(suggestion.name)) {
+        fragments.add(suggestion.name);
+      }
+      if (!String.isBlank(suggestion.productCode)) {
+        fragments.add('商品コード: ' + suggestion.productCode);
+      }
+      if (suggestion.unitPrice != null) {
+        fragments.add(
+          '価格: ¥' + String.valueOf(Math.round(suggestion.unitPrice))
+        );
+      }
+      parts.add(String.join(fragments, ' / '));
+    }
+    return '代替候補: ' + String.join(parts, '、 ');
+  }
+
+  public static Decimal getProductUnitPrice(Product2 product) {
+    Id standardPricebookId = getStandardPricebookIdSafe();
+    if (product == null || standardPricebookId == null) {
+      return null;
+    }
+
+    List<PricebookEntry> entries = [
+      SELECT UnitPrice
+      FROM PricebookEntry
+      WHERE
+        Pricebook2Id = :standardPricebookId
+        AND Product2Id = :product.Id
+        AND IsActive = TRUE
+      LIMIT 1
+    ];
+    return entries.isEmpty() ? null : entries[0].UnitPrice;
+  }
+
+  private static Id getStandardPricebookIdSafe() {
+    try {
+      if (Test.isRunningTest()) {
+        return Test.getStandardPricebookId();
+      }
+
+      List<Pricebook2> standard = [
+        SELECT Id
+        FROM Pricebook2
+        WHERE IsStandard = TRUE
+        LIMIT 1
+      ];
+      return standard.isEmpty() ? null : standard[0].Id;
+    } catch (Exception ex) {
+      return null;
+    }
+  }
+}

--- a/force-app/main/default/classes/ReturnProductEligibilityService.cls-meta.xml
+++ b/force-app/main/default/classes/ReturnProductEligibilityService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/ReturnReasonEvaluationService.cls
+++ b/force-app/main/default/classes/ReturnReasonEvaluationService.cls
@@ -1,0 +1,408 @@
+public with sharing class ReturnReasonEvaluationService {
+  public enum ReturnReasonCategory {
+    DEFECTIVE,
+    SIZE_FIT,
+    APPEARANCE,
+    UNWANTED,
+    OTHER
+  }
+
+  private static final Set<ReturnReasonCategory> ALL_REASON_CATEGORIES = new Set<ReturnReasonCategory>(
+    ReturnReasonCategory.values()
+  );
+  private static final Map<ReturnReasonCategory, String> CATEGORY_LABELS = buildReasonCategoryLabels();
+  private static final Map<String, ReturnReasonCategory> LABEL_TO_CATEGORY = buildLabelToReasonCategoryMap();
+  private static final Map<String, Set<ReturnReasonCategory>> POLICY_REASON_MAP = buildPolicyReasonMap();
+
+  public class ReasonEvaluationInput {
+    @InvocableVariable(required=true)
+    public String returnReason;
+
+    @InvocableVariable
+    public Id policyId;
+
+    @InvocableVariable
+    public Id policyProductId;
+
+    @InvocableVariable
+    public String policyName;
+
+    @InvocableVariable
+    public String policyType;
+
+    @InvocableVariable
+    public String policyDescription;
+
+    @InvocableVariable
+    public Id productId;
+
+    @InvocableVariable
+    public String productName;
+
+    @InvocableVariable
+    public String productCode;
+
+    @InvocableVariable
+    public String productFamily;
+
+    @InvocableVariable
+    public String productDescription;
+
+    @InvocableVariable
+    public Decimal productUnitPrice;
+  }
+
+  @InvocableMethod(
+    label='返品理由の判定',
+    description='入力された返品理由をカテゴリ判定し、ポリシー適合を確認して最終的な可否を返します。'
+  )
+  public static List<ReturnEligibilityService.EvaluationResult> evaluateForFlow(
+    List<ReasonEvaluationInput> inputs
+  ) {
+    List<ReturnEligibilityService.EvaluationResult> results = new List<ReturnEligibilityService.EvaluationResult>();
+    if (inputs == null) {
+      return results;
+    }
+
+    Set<Id> productIds = new Set<Id>();
+    Set<Id> policyIds = new Set<Id>();
+    for (ReasonEvaluationInput input : inputs) {
+      if (input == null) {
+        continue;
+      }
+      if (input.productId != null) {
+        productIds.add(input.productId);
+      }
+      if (input.policyId != null) {
+        policyIds.add(input.policyId);
+      }
+    }
+
+    Map<Id, Product2> productsById = productIds.isEmpty()
+      ? new Map<Id, Product2>()
+      : new Map<Id, Product2>([
+          SELECT Id, Name, ProductCode, Family, Description
+          FROM Product2
+          WHERE Id IN :productIds
+        ]);
+
+    Map<Id, StorePolicy__c> policiesById = policyIds.isEmpty()
+      ? new Map<Id, StorePolicy__c>()
+      : new Map<Id, StorePolicy__c>([
+          SELECT Id, Name, PolicyType__c, Description__c, IsActive__c, ValidFrom__c, ValidTo__c
+          FROM StorePolicy__c
+          WHERE Id IN :policyIds
+        ]);
+
+    for (ReasonEvaluationInput input : inputs) {
+      ReturnEligibilityService.EvaluationResult baseResult = new ReturnEligibilityService.EvaluationResult();
+      if (input == null) {
+        results.add(baseResult);
+        continue;
+      }
+
+      baseResult.productId = input.productId;
+      baseResult.productName = input.productName;
+      baseResult.productCode = input.productCode;
+      baseResult.productFamily = input.productFamily;
+      baseResult.productDescription = input.productDescription;
+      baseResult.productUnitPrice = input.productUnitPrice;
+      baseResult.productFound = input.productId != null;
+      baseResult.policyId = input.policyId;
+      baseResult.policyProductId = input.policyProductId;
+      baseResult.policyName = input.policyName;
+      baseResult.policyType = input.policyType;
+      baseResult.policyDescription = input.policyDescription;
+      baseResult.isReturnable = true;
+      baseResult.requiresReason = true;
+      baseResult.reasonAccepted = false;
+      baseResult.status = 'AWAITING_REASON';
+      baseResult.primaryMessage = '返品理由をお聞かせください。';
+      baseResult.secondaryMessage = '該当する理由カテゴリを選択してください。';
+      baseResult.availableReasonCategories = getAvailableReasonLabels();
+
+      Product2 product = input.productId != null
+        ? productsById.get(input.productId)
+        : null;
+      if (product != null) {
+        baseResult.productFound = true;
+        baseResult.productId = product.Id;
+        baseResult.productName = product.Name;
+        baseResult.productCode = product.ProductCode;
+        baseResult.productFamily = product.Family;
+        baseResult.productDescription = product.Description;
+        if (baseResult.productUnitPrice == null) {
+          baseResult.productUnitPrice = ReturnProductEligibilityService.getProductUnitPrice(
+            product
+          );
+        }
+      }
+
+      if (
+        product == null &&
+        (input.productId != null ||
+        !String.isBlank(input.productName) ||
+        !String.isBlank(input.productCode))
+      ) {
+        product = new Product2(
+          Id = input.productId,
+          Name = input.productName,
+          ProductCode = input.productCode,
+          Family = input.productFamily,
+          Description = input.productDescription
+        );
+      }
+
+      StorePolicy__c policy = input.policyId != null
+        ? policiesById.get(input.policyId)
+        : null;
+      if (policy != null) {
+        baseResult.policyId = policy.Id;
+        baseResult.policyName = policy.Name;
+        baseResult.policyType = policy.PolicyType__c;
+        baseResult.policyDescription = policy.Description__c;
+      }
+
+      if (
+        policy == null &&
+        (input.policyId != null ||
+        !String.isBlank(input.policyType) ||
+        !String.isBlank(input.policyName) ||
+        !String.isBlank(input.policyDescription))
+      ) {
+        policy = new StorePolicy__c(
+          Id = input.policyId,
+          Name = input.policyName,
+          PolicyType__c = input.policyType,
+          Description__c = input.policyDescription
+        );
+      }
+
+      results.add(
+        evaluate(
+          input.returnReason,
+          policy,
+          baseResult,
+          product
+        )
+      );
+    }
+
+    return results;
+  }
+
+  public static List<String> getAvailableReasonLabels() {
+    return new List<String>(CATEGORY_LABELS.values());
+  }
+
+  public static ReturnEligibilityService.EvaluationResult evaluate(
+    String returnReason,
+    StorePolicy__c policy,
+    ReturnEligibilityService.EvaluationResult result,
+    Product2 product
+  ) {
+    if (result == null) {
+      result = new ReturnEligibilityService.EvaluationResult();
+    }
+
+    String normalizedReason = returnReason != null ? returnReason.trim() : null;
+    if (String.isBlank(normalizedReason)) {
+      result.isReturnable = true;
+      result.requiresReason = true;
+      result.status = 'ASK_REASON';
+      result.primaryMessage = '返品理由をお聞かせください。';
+      result.availableReasonCategories = getAvailableReasonLabels();
+      return result;
+    }
+
+    ReturnReasonCategory category = resolveReasonCategory(normalizedReason);
+    if (category == null) {
+      result.requiresReason = true;
+      result.status = 'INVALID_REASON_CATEGORY';
+      result.primaryMessage = '入力された返品理由を認識できません。もう一度ご入力ください。';
+      result.reasonCategory = normalizedReason;
+      result.availableReasonCategories = getAvailableReasonLabels();
+      return result;
+    }
+
+    result.reasonCategory = CATEGORY_LABELS.get(category);
+
+    if (
+      !isReasonAllowedByPolicy(
+        policy != null ? policy.PolicyType__c : null,
+        category
+      )
+    ) {
+      ReturnProductEligibilityService.applyReturnDenied(result, product);
+      result.status = 'RETURN_REJECTED_REASON';
+      result.reasonAccepted = false;
+      return result;
+    }
+
+    markReturnApproved(result);
+    return result;
+  }
+
+  private static Boolean isReasonAllowedByPolicy(
+    String policyType,
+    ReturnReasonCategory category
+  ) {
+    if (category == null) {
+      return false;
+    }
+
+    if (String.isBlank(policyType)) {
+      return category != ReturnReasonCategory.OTHER;
+    }
+
+    String key = policyType.trim().toUpperCase();
+    if (POLICY_REASON_MAP.containsKey(key)) {
+      Set<ReturnReasonCategory> allowed = POLICY_REASON_MAP.get(key);
+      return allowed != null && allowed.contains(category);
+    }
+
+    return false;
+  }
+
+  private static ReturnReasonCategory resolveReasonCategory(
+    String reasonValue
+  ) {
+    if (String.isBlank(reasonValue)) {
+      return null;
+    }
+
+    String candidate = extractCategoryToken(reasonValue);
+    if (String.isBlank(candidate)) {
+      return null;
+    }
+
+    String normalized = candidate.replace('-', '_')
+      .replace(' ', '_')
+      .toUpperCase();
+    try {
+      return ReturnReasonCategory.valueOf(normalized);
+    } catch (Exception ex) {
+      if (LABEL_TO_CATEGORY.containsKey(candidate)) {
+        return LABEL_TO_CATEGORY.get(candidate);
+      }
+      return null;
+    }
+  }
+
+  private static String extractCategoryToken(String rawValue) {
+    if (String.isBlank(rawValue)) {
+      return null;
+    }
+
+    String trimmed = rawValue.trim();
+    if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
+      try {
+        Map<String, Object> payload = (Map<String, Object>) JSON.deserializeUntyped(
+          trimmed
+        );
+        if (payload != null) {
+          Object categoryValue = payload.get('category');
+          if (categoryValue instanceof String) {
+            String categoryString = ((String) categoryValue).trim();
+            if (!String.isBlank(categoryString)) {
+              return categoryString;
+            }
+          }
+        }
+      } catch (Exception ex) {
+        // Ignore malformed JSON and continue with fallback handling.
+      }
+    }
+
+    return trimmed;
+  }
+
+  private static Map<ReturnReasonCategory, String> buildReasonCategoryLabels() {
+    Map<ReturnReasonCategory, String> labels = new Map<ReturnReasonCategory, String>();
+    labels.put(ReturnReasonCategory.DEFECTIVE, '不良・破損');
+    labels.put(ReturnReasonCategory.SIZE_FIT, 'サイズが合わない');
+    labels.put(ReturnReasonCategory.APPEARANCE, 'イメージと違う');
+    labels.put(ReturnReasonCategory.UNWANTED, '不要になった');
+    labels.put(ReturnReasonCategory.OTHER, 'その他');
+    return labels;
+  }
+
+  private static Map<String, ReturnReasonCategory> buildLabelToReasonCategoryMap() {
+    Map<String, ReturnReasonCategory> mapping = new Map<String, ReturnReasonCategory>();
+    for (ReturnReasonCategory category : ReturnReasonCategory.values()) {
+      String label = CATEGORY_LABELS.get(category);
+      if (!String.isBlank(label)) {
+        mapping.put(label, category);
+      }
+    }
+    return mapping;
+  }
+
+  private static Map<String, Set<ReturnReasonCategory>> buildPolicyReasonMap() {
+    Map<String, Set<ReturnReasonCategory>> mapping = new Map<String, Set<ReturnReasonCategory>>();
+    mapping.put(
+      'RETURN_ALL',
+      new Set<ReturnReasonCategory>(ALL_REASON_CATEGORIES)
+    );
+    mapping.put(
+      'RETURN_DEFECTIVE_ONLY',
+      new Set<ReturnReasonCategory>{ ReturnReasonCategory.DEFECTIVE }
+    );
+    mapping.put(
+      'RETURN_DEFECTIVE_SIZE',
+      new Set<ReturnReasonCategory>{
+        ReturnReasonCategory.DEFECTIVE,
+        ReturnReasonCategory.SIZE_FIT
+      }
+    );
+    mapping.put(
+      'RETURN_SIZE_ONLY',
+      new Set<ReturnReasonCategory>{ ReturnReasonCategory.SIZE_FIT }
+    );
+    mapping.put(
+      'RETURN_APPEARANCE',
+      new Set<ReturnReasonCategory>{ ReturnReasonCategory.APPEARANCE }
+    );
+    mapping.put(
+      'RETURN_SATISFACTION',
+      new Set<ReturnReasonCategory>{
+        ReturnReasonCategory.APPEARANCE,
+        ReturnReasonCategory.UNWANTED
+      }
+    );
+    mapping.put(
+      'RETURN_UNWANTED',
+      new Set<ReturnReasonCategory>{ ReturnReasonCategory.UNWANTED }
+    );
+    mapping.put(
+      'RETURN_OTHER',
+      new Set<ReturnReasonCategory>{ ReturnReasonCategory.OTHER }
+    );
+    mapping.put(
+      'RETURN_DEFECTIVE_APPEARANCE',
+      new Set<ReturnReasonCategory>{
+        ReturnReasonCategory.DEFECTIVE,
+        ReturnReasonCategory.APPEARANCE
+      }
+    );
+    mapping.put(
+      'RETURN_DEFECTIVE_SATISFACTION',
+      new Set<ReturnReasonCategory>{
+        ReturnReasonCategory.DEFECTIVE,
+        ReturnReasonCategory.APPEARANCE,
+        ReturnReasonCategory.UNWANTED
+      }
+    );
+    return mapping;
+  }
+
+  private static void markReturnApproved(
+    ReturnEligibilityService.EvaluationResult result
+  ) {
+    result.isReturnable = true;
+    result.reasonAccepted = true;
+    result.requiresReason = false;
+    result.primaryMessage = 'ご迷惑をおかけし、誠に申し訳ございません。すぐに新しい商品をお送りいたしますが、よろしいでしょうか？';
+    result.status = 'RETURN_APPROVED';
+  }
+}

--- a/force-app/main/default/classes/ReturnReasonEvaluationService.cls-meta.xml
+++ b/force-app/main/default/classes/ReturnReasonEvaluationService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
## Summary
- add a flow-invocable interface to `ReturnProductEligibilityService` so product checks can run independently
- extend `ReturnEligibilityService.EvaluationResult` with product and policy context for downstream flows
- provide a flow-invocable path in `ReturnReasonEvaluationService` that reuses product context and policy data when validating reasons

## Testing
- npm test *(fails: `sfdx-lwc-jest` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_69034abae52c832c85dc0b5aff78d933