### PR TITLE
Implement in-service return order record creation

### DIFF
--- a/force-app/main/default/classes/ReturnOrderProcessingService.cls
+++ b/force-app/main/default/classes/ReturnOrderProcessingService.cls
@@ -1,160 +1,562 @@
 public with sharing class ReturnOrderProcessingService {
-    public class Request {
-        @AuraEnabled
-        public String orderNumber;
-
-        @AuraEnabled
-        public String productCode;
-
-        @AuraEnabled
-        public Decimal quantity;
-
-        @AuraEnabled
-        public String returnReason;
-    }
-
-    public class Response {
-        @AuraEnabled
-        public Boolean success;
-
-        @AuraEnabled
-        public String status;
-
-        @AuraEnabled
-        public String primaryMessage;
-
-        @AuraEnabled
-        public String secondaryMessage;
-
-        @AuraEnabled
-        public String returnOrderNumber;
-
-        @AuraEnabled
-        public String caseNumber;
-
-        @AuraEnabled
-        public ReturnEligibilityService.EvaluationResult evaluation;
-    }
-
-    private class FlowOutcome {
-        Boolean success = false;
-        String returnOrderNumber;
-        String caseNumber;
-        String errorMessage;
-    }
+  public class Request {
+    @AuraEnabled
+    public String orderNumber;
 
     @AuraEnabled
-    public static Response processReturn(Request request) {
-        if (request == null) {
-            throw new AuraHandledException('返品手続きを進めるには注文情報が必要です。');
-        }
+    public String productCode;
 
-        String normalizedOrderNumber = request.orderNumber != null ? request.orderNumber.trim() : null;
-        String normalizedProductCode = request.productCode != null ? request.productCode.trim() : null;
-        String normalizedReturnReason = request.returnReason != null ? request.returnReason.trim() : null;
-        Decimal quantity = request.quantity;
+    @AuraEnabled
+    public Decimal quantity;
 
-        validateInputs(normalizedOrderNumber, normalizedProductCode, quantity);
+    @AuraEnabled
+    public String returnReason;
+  }
 
-        ReturnEligibilityService.EvaluationResult evaluation = ReturnEligibilityService.evaluateProductReturn(
-            normalizedProductCode,
-            normalizedReturnReason
-        );
+  public class Response {
+    @AuraEnabled
+    public Boolean success;
 
-        Response response = new Response();
-        response.evaluation = evaluation;
+    @AuraEnabled
+    public String status;
 
-        if (evaluation == null) {
-            response.success = false;
-            response.status = 'EVALUATION_FAILED';
-            response.primaryMessage = '返品手続きを進めることができませんでした。お手数ですが、再度お試しください。';
-            return response;
-        }
+    @AuraEnabled
+    public String primaryMessage;
 
-        if (!(Boolean.TRUE.equals(evaluation.productFound) &&
-              Boolean.TRUE.equals(evaluation.isReturnable) &&
-              Boolean.TRUE.equals(evaluation.reasonAccepted))) {
-            response.success = false;
-            response.status = evaluation.status;
-            response.primaryMessage = evaluation.primaryMessage;
-            response.secondaryMessage = evaluation.secondaryMessage;
-            return response;
-        }
+    @AuraEnabled
+    public String secondaryMessage;
 
-        FlowOutcome outcome = executeReturnOrderFlow(
-            normalizedOrderNumber,
-            normalizedProductCode,
-            quantity,
-            normalizedReturnReason
-        );
+    @AuraEnabled
+    public String returnOrderNumber;
 
-        if (outcome.success) {
-            response.success = true;
-            response.status = 'RETURN_ORDER_CREATED';
-            response.returnOrderNumber = outcome.returnOrderNumber;
-            response.caseNumber = outcome.caseNumber;
-            response.primaryMessage = buildSuccessMessage(outcome.returnOrderNumber);
-            response.secondaryMessage = null;
-        } else {
-            response.success = false;
-            response.status = 'RETURN_ORDER_FAILED';
-            response.returnOrderNumber = null;
-            response.caseNumber = null;
-            response.primaryMessage = 'システムエラーにより返品手続きが完了しませんでした。お手数ですが、再度お試しください。';
-            response.secondaryMessage = String.isBlank(outcome.errorMessage) ? null : outcome.errorMessage;
-        }
+    @AuraEnabled
+    public String caseNumber;
 
-        return response;
+    @AuraEnabled
+    public ReturnEligibilityService.EvaluationResult evaluation;
+  }
+
+  private class ReturnOrderOutcome {
+    Boolean success = false;
+    String returnOrderNumber;
+    String caseNumber;
+    String errorMessage;
+  }
+
+  @AuraEnabled
+  public static Response processReturn(Request request) {
+    if (request == null) {
+      throw new AuraHandledException(
+        '返品手続きを進めるには注文情報が必要です。'
+      );
     }
 
-    private static void validateInputs(String orderNumber, String productCode, Decimal quantity) {
-        if (String.isBlank(orderNumber)) {
-            throw new AuraHandledException('返品手続きを進めるには注文番号が必要です。');
-        }
+    String normalizedOrderNumber = request.orderNumber != null
+      ? request.orderNumber.trim()
+      : null;
+    String normalizedProductCode = request.productCode != null
+      ? request.productCode.trim()
+      : null;
+    String normalizedReturnReason = request.returnReason != null
+      ? request.returnReason.trim()
+      : null;
+    Decimal quantity = request.quantity;
 
-        if (String.isBlank(productCode)) {
-            throw new AuraHandledException('返品手続きを進めるには商品コードが必要です。');
-        }
+    validateInputs(normalizedOrderNumber, normalizedProductCode, quantity);
 
-        if (quantity == null || quantity <= 0) {
-            throw new AuraHandledException('返品数量は1以上の数値を指定してください。');
-        }
+    ReturnEligibilityService.EvaluationResult evaluation = ReturnEligibilityService.evaluateProductReturn(
+      normalizedProductCode,
+      normalizedReturnReason
+    );
+
+    Response response = new Response();
+    response.evaluation = evaluation;
+
+    if (evaluation == null) {
+      response.success = false;
+      response.status = 'EVALUATION_FAILED';
+      response.primaryMessage = '返品手続きを進めることができませんでした。お手数ですが、再度お試しください。';
+      return response;
     }
 
-    private static String buildSuccessMessage(String returnOrderNumber) {
-        String number = String.isBlank(returnOrderNumber) ? '不明' : returnOrderNumber;
-        return '返品手続きが完了しました。返品注文番号は『' + number + '』です。この番号をお控えください。担当者が確認次第、メールにてご連絡いたします。';
+    if (
+      !(Boolean.TRUE.equals(evaluation.productFound) &&
+      Boolean.TRUE.equals(evaluation.isReturnable) &&
+      Boolean.TRUE.equals(evaluation.reasonAccepted))
+    ) {
+      response.success = false;
+      response.status = evaluation.status;
+      response.primaryMessage = evaluation.primaryMessage;
+      response.secondaryMessage = evaluation.secondaryMessage;
+      return response;
     }
 
-    private static FlowOutcome executeReturnOrderFlow(String orderNumber,
-                                                       String productCode,
-                                                       Decimal quantity,
-                                                       String returnReason) {
-        FlowOutcome outcome = new FlowOutcome();
-        Map<String, Object> inputs = new Map<String, Object>{
-            'OrderNumber' => orderNumber,
-            'ProductCode' => productCode,
-            'Quantity' => quantity,
-            'ReturnReason' => returnReason
-        };
+    ReturnOrderOutcome outcome = createReturnOrder(
+      normalizedOrderNumber,
+      normalizedProductCode,
+      quantity,
+      normalizedReturnReason
+    );
 
-        try {
-            Flow.Interview interview = Flow.Interview.createInterview('ReturnOrderFlow', inputs);
-            interview.start();
+    if (outcome.success) {
+      response.success = true;
+      response.status = 'RETURN_ORDER_CREATED';
+      response.returnOrderNumber = outcome.returnOrderNumber;
+      response.caseNumber = outcome.caseNumber;
+      response.primaryMessage = buildSuccessMessage(outcome.returnOrderNumber);
+      response.secondaryMessage = null;
+    } else {
+      response.success = false;
+      response.status = 'RETURN_ORDER_FAILED';
+      response.returnOrderNumber = null;
+      response.caseNumber = null;
+      response.primaryMessage = 'システムエラーにより返品手続きが完了しませんでした。お手数ですが、再度お試しください。';
+      response.secondaryMessage = String.isBlank(outcome.errorMessage)
+        ? null
+        : outcome.errorMessage;
+    }
 
-            outcome.returnOrderNumber = (String) interview.getVariableValue('varReturnOrderNumber');
-            outcome.caseNumber = (String) interview.getVariableValue('varCaseNumber');
-            if (String.isBlank(outcome.returnOrderNumber)) {
-                outcome.success = false;
-                outcome.errorMessage = 'フローから返品注文番号が返されませんでした。';
-            } else {
-                outcome.success = true;
-            }
-        } catch (Exception e) {
-            outcome.success = false;
-            outcome.errorMessage = e != null ? e.getMessage() : null;
+    return response;
+  }
+
+  private static void validateInputs(
+    String orderNumber,
+    String productCode,
+    Decimal quantity
+  ) {
+    if (String.isBlank(orderNumber)) {
+      throw new AuraHandledException(
+        '返品手続きを進めるには注文番号が必要です。'
+      );
+    }
+
+    if (String.isBlank(productCode)) {
+      throw new AuraHandledException(
+        '返品手続きを進めるには商品コードが必要です。'
+      );
+    }
+
+    if (quantity == null || quantity <= 0) {
+      throw new AuraHandledException(
+        '返品数量は1以上の数値を指定してください。'
+      );
+    }
+  }
+
+  private static String buildSuccessMessage(String returnOrderNumber) {
+    String number = String.isBlank(returnOrderNumber)
+      ? '不明'
+      : returnOrderNumber;
+    return '返品手続きが完了しました。返品注文番号は『' +
+      number +
+      '』です。この番号をお控えください。担当者が確認次第、メールにてご連絡いたします。';
+  }
+
+  private static ReturnOrderOutcome createReturnOrder(
+    String orderNumber,
+    String productCode,
+    Decimal quantity,
+    String returnReason
+  ) {
+    ReturnOrderOutcome outcome = new ReturnOrderOutcome();
+
+    if (quantity == null || quantity <= 0) {
+      outcome.errorMessage = '返品数量が正しくありません。';
+      return outcome;
+    }
+
+    Order orderRecord = findOrder(orderNumber);
+    if (orderRecord == null) {
+      outcome.errorMessage = '指定された注文が見つかりません。正しい注文番号を入力してください。';
+      return outcome;
+    }
+
+    OrderItem orderItemRecord = findOrderItem(orderRecord.Id, productCode);
+    if (orderItemRecord == null) {
+      outcome.errorMessage = '指定された商品はこの注文に含まれていません。';
+      return outcome;
+    }
+
+    try {
+      SObject returnOrder = buildReturnOrderRecord(orderRecord, returnReason);
+      insert returnOrder;
+
+      SObject returnOrderLineItem = buildReturnOrderLineItem(
+        returnOrder,
+        orderItemRecord,
+        quantity,
+        returnReason
+      );
+      insert returnOrderLineItem;
+
+      SObject adjustment = buildReturnOrderLineItemAdjustment(
+        returnOrderLineItem
+      );
+      if (adjustment != null) {
+        insert adjustment;
+      }
+
+      SObject tax = buildReturnOrderLineItemTax(
+        returnOrderLineItem,
+        orderItemRecord,
+        quantity
+      );
+      if (tax != null) {
+        insert tax;
+      }
+
+      outcome.success = true;
+      outcome.returnOrderNumber = extractReturnOrderNumber(returnOrder);
+      outcome.caseNumber = null;
+    } catch (Exception e) {
+      outcome.success = false;
+      outcome.errorMessage = e != null ? e.getMessage() : null;
+    }
+
+    return outcome;
+  }
+
+  private static Order findOrder(String orderNumber) {
+    if (String.isBlank(orderNumber)) {
+      return null;
+    }
+
+    List<Order> orders = [
+      SELECT Id, AccountId, Pricebook2Id
+      FROM Order
+      WHERE OrderNumber = :orderNumber
+      LIMIT 1
+    ];
+
+    return orders.isEmpty() ? null : orders[0];
+  }
+
+  private static OrderItem findOrderItem(Id orderId, String productCode) {
+    if (orderId == null || String.isBlank(productCode)) {
+      return null;
+    }
+
+    List<OrderItem> items = [
+      SELECT
+        Id,
+        Quantity,
+        UnitPrice,
+        PricebookEntryId,
+        Product2Id,
+        Product2.ProductCode
+      FROM OrderItem
+      WHERE OrderId = :orderId AND Product2.ProductCode = :productCode
+      LIMIT 1
+    ];
+
+    return items.isEmpty() ? null : items[0];
+  }
+
+  private static SObject buildReturnOrderRecord(
+    Order orderRecord,
+    String returnReason
+  ) {
+    Schema.SObjectType typeInfo = Schema.getGlobalDescribe().get('ReturnOrder');
+    if (typeInfo == null) {
+      throw new AuraHandledException(
+        'Return Order オブジェクトが組織で利用できません。'
+      );
+    }
+
+    Schema.DescribeSObjectResult describe = typeInfo.getDescribe();
+    if (!describe.isCreateable()) {
+      throw new AuraHandledException('Return Order の作成権限がありません。');
+    }
+
+    SObject record = typeInfo.newSObject();
+    Map<String, Schema.SObjectField> fields = describe.fields.getMap();
+
+    setReferenceField(record, fields, 'OrderId', orderRecord.Id);
+    setReferenceField(record, fields, 'AccountId', orderRecord.AccountId);
+    setReferenceField(record, fields, 'OwnerId', UserInfo.getUserId());
+    setTextField(record, fields, 'ReturnReason', returnReason);
+
+    populateRequiredDefaults(record, describe);
+    return record;
+  }
+
+  private static SObject buildReturnOrderLineItem(
+    SObject returnOrder,
+    OrderItem orderItem,
+    Decimal quantity,
+    String returnReason
+  ) {
+    Schema.SObjectType typeInfo = Schema.getGlobalDescribe()
+      .get('ReturnOrderLineItem');
+    if (typeInfo == null) {
+      throw new AuraHandledException(
+        'Return Order Line Item オブジェクトが組織で利用できません。'
+      );
+    }
+
+    Schema.DescribeSObjectResult describe = typeInfo.getDescribe();
+    if (!describe.isCreateable()) {
+      throw new AuraHandledException(
+        'Return Order Line Item の作成権限がありません。'
+      );
+    }
+
+    SObject record = typeInfo.newSObject();
+    Map<String, Schema.SObjectField> fields = describe.fields.getMap();
+
+    setReferenceField(
+      record,
+      fields,
+      'ReturnOrderId',
+      (Id) returnOrder.get('Id')
+    );
+    setReferenceField(record, fields, 'OrderItemId', orderItem.Id);
+    setReferenceField(record, fields, 'OwnerId', UserInfo.getUserId());
+    setReferenceField(record, fields, 'Product2Id', orderItem.Product2Id);
+    setReferenceField(
+      record,
+      fields,
+      'PricebookEntryId',
+      orderItem.PricebookEntryId
+    );
+
+    setDecimalField(record, fields, 'Quantity', quantity);
+    setDecimalField(record, fields, 'UnitPrice', orderItem.UnitPrice);
+    setTextField(record, fields, 'ReturnReason', returnReason);
+
+    populateRequiredDefaults(record, describe);
+    return record;
+  }
+
+  private static SObject buildReturnOrderLineItemAdjustment(
+    SObject returnOrderLineItem
+  ) {
+    Schema.SObjectType typeInfo = Schema.getGlobalDescribe()
+      .get('ReturnOrderLineItemAdjustment');
+    if (typeInfo == null) {
+      return null;
+    }
+
+    Schema.DescribeSObjectResult describe = typeInfo.getDescribe();
+    if (!describe.isCreateable()) {
+      return null;
+    }
+
+    SObject record = typeInfo.newSObject();
+    Map<String, Schema.SObjectField> fields = describe.fields.getMap();
+
+    setReferenceField(
+      record,
+      fields,
+      'ReturnOrderLineItemId',
+      (Id) returnOrderLineItem.get('Id')
+    );
+    setReferenceField(record, fields, 'OwnerId', UserInfo.getUserId());
+    setDecimalField(record, fields, 'Amount', 0);
+
+    populateRequiredDefaults(record, describe);
+    return record;
+  }
+
+  private static SObject buildReturnOrderLineItemTax(
+    SObject returnOrderLineItem,
+    OrderItem orderItem,
+    Decimal quantity
+  ) {
+    Schema.SObjectType typeInfo = Schema.getGlobalDescribe()
+      .get('ReturnOrderLineItemTax');
+    if (typeInfo == null) {
+      return null;
+    }
+
+    Schema.DescribeSObjectResult describe = typeInfo.getDescribe();
+    if (!describe.isCreateable()) {
+      return null;
+    }
+
+    Decimal unitPrice = orderItem.UnitPrice != null ? orderItem.UnitPrice : 0;
+    Decimal totalAmount = quantity != null ? quantity * unitPrice : 0;
+    Decimal taxRate = 0.1;
+    Decimal taxAmount = totalAmount * taxRate;
+
+    SObject record = typeInfo.newSObject();
+    Map<String, Schema.SObjectField> fields = describe.fields.getMap();
+
+    setReferenceField(
+      record,
+      fields,
+      'ReturnOrderLineItemId',
+      (Id) returnOrderLineItem.get('Id')
+    );
+    setReferenceField(record, fields, 'OwnerId', UserInfo.getUserId());
+    setDecimalField(record, fields, 'TaxAmount', taxAmount);
+    setDecimalField(record, fields, 'TaxRate', taxRate);
+
+    populateRequiredDefaults(record, describe);
+    return record;
+  }
+
+  private static void setReferenceField(
+    SObject record,
+    Map<String, Schema.SObjectField> fields,
+    String fieldName,
+    Id value
+  ) {
+    if (value == null) {
+      return;
+    }
+
+    if (fields != null && fields.containsKey(fieldName)) {
+      Schema.DescribeFieldResult describe = fields.get(fieldName).getDescribe();
+      if (describe.isCreateable()) {
+        record.put(fieldName, value);
+      }
+    }
+  }
+
+  private static void setTextField(
+    SObject record,
+    Map<String, Schema.SObjectField> fields,
+    String fieldName,
+    String value
+  ) {
+    if (String.isBlank(value)) {
+      return;
+    }
+
+    if (fields != null && fields.containsKey(fieldName)) {
+      Schema.DescribeFieldResult describe = fields.get(fieldName).getDescribe();
+      if (describe.isCreateable()) {
+        record.put(fieldName, value);
+      }
+    }
+  }
+
+  private static void setDecimalField(
+    SObject record,
+    Map<String, Schema.SObjectField> fields,
+    String fieldName,
+    Decimal value
+  ) {
+    if (value == null) {
+      return;
+    }
+
+    if (fields != null && fields.containsKey(fieldName)) {
+      Schema.DescribeFieldResult describe = fields.get(fieldName).getDescribe();
+      if (describe.isCreateable()) {
+        record.put(fieldName, value);
+      }
+    }
+  }
+
+  private static void populateRequiredDefaults(
+    SObject record,
+    Schema.DescribeSObjectResult describe
+  ) {
+    if (record == null || describe == null) {
+      return;
+    }
+
+    Map<String, Schema.SObjectField> fields = describe.fields.getMap();
+    for (String fieldName : fields.keySet()) {
+      Schema.DescribeFieldResult fieldDescribe = fields.get(fieldName)
+        .getDescribe();
+
+      if (!fieldDescribe.isCreateable()) {
+        continue;
+      }
+
+      if (record.get(fieldName) != null) {
+        continue;
+      }
+
+      if (fieldDescribe.isDefaultedOnCreate() || fieldDescribe.isAutoNumber()) {
+        continue;
+      }
+
+      if (!fieldDescribe.isNillable()) {
+        Schema.DisplayType type = fieldDescribe.getType();
+        if (type == Schema.DisplayType.Picklist) {
+          String value = getFirstPicklistValue(fieldDescribe);
+          if (value != null) {
+            record.put(fieldName, value);
+          }
+        } else if (type == Schema.DisplayType.Boolean) {
+          record.put(fieldName, false);
+        } else if (type == Schema.DisplayType.Date) {
+          record.put(fieldName, Date.today());
+        } else if (type == Schema.DisplayType.Datetime) {
+          record.put(fieldName, Datetime.now());
+        } else if (
+          type == Schema.DisplayType.Double ||
+          type == Schema.DisplayType.Currency ||
+          type == Schema.DisplayType.Integer ||
+          type == Schema.DisplayType.Long ||
+          type == Schema.DisplayType.Percent
+        ) {
+          record.put(fieldName, 0);
+        } else if (
+          type == Schema.DisplayType.String ||
+          type == Schema.DisplayType.TextArea ||
+          type == Schema.DisplayType.EncryptedString
+        ) {
+          record.put(fieldName, 'N/A');
+        } else if (
+          type == Schema.DisplayType.Reference && 'OwnerId'.equals(fieldName)
+        ) {
+          record.put(fieldName, UserInfo.getUserId());
         }
-
-        return outcome;
+      }
     }
+  }
+
+  private static String getFirstPicklistValue(
+    Schema.DescribeFieldResult fieldDescribe
+  ) {
+    if (fieldDescribe == null) {
+      return null;
+    }
+
+    for (Schema.PicklistEntry entry : fieldDescribe.getPicklistValues()) {
+      if (entry.isActive()) {
+        return entry.getValue();
+      }
+    }
+
+    List<Schema.PicklistEntry> values = fieldDescribe.getPicklistValues();
+    return values.isEmpty() ? null : values[0].getValue();
+  }
+
+  private static String extractReturnOrderNumber(SObject returnOrder) {
+    if (returnOrder == null) {
+      return null;
+    }
+
+    if (
+      returnOrder.getSObjectType()
+        .getDescribe()
+        .fields.getMap()
+        .containsKey('ReturnOrderNumber')
+    ) {
+      String number = (String) returnOrder.get('ReturnOrderNumber');
+      if (!String.isBlank(number)) {
+        return number;
+      }
+    }
+
+    if (
+      returnOrder.getSObjectType()
+        .getDescribe()
+        .fields.getMap()
+        .containsKey('Name')
+    ) {
+      String name = (String) returnOrder.get('Name');
+      if (!String.isBlank(name)) {
+        return name;
+      }
+    }
+
+    return (String) returnOrder.get('Id');
+  }
 }

--- a/force-app/main/default/classes/ReturnOrderProcessingServiceTest.cls
+++ b/force-app/main/default/classes/ReturnOrderProcessingServiceTest.cls
@@ -1,267 +1,396 @@
 @IsTest
 private class ReturnOrderProcessingServiceTest {
-    @IsTest
-    static void testProcessReturnSuccess() {
-        TestData data = TestData.setup();
-        Test.setMock(Flow.Interview.Mock.class, new SuccessfulReturnOrderFlowMock());
+  @IsTest
+  static void testProcessReturnSuccess() {
+    TestData data = TestData.setup();
 
-        ReturnOrderProcessingService.Request request = new ReturnOrderProcessingService.Request();
-        request.orderNumber = 'ORD-10001';
-        request.productCode = data.returnableProductCode;
-        request.quantity = 1;
-        request.returnReason = '  糸のほつれがありました  ';
+    ReturnOrderProcessingService.Request request = new ReturnOrderProcessingService.Request();
+    request.orderNumber = data.orderNumber;
+    request.productCode = data.returnableProductCode;
+    request.quantity = 1;
+    request.returnReason = '  糸のほつれがありました  ';
 
-        Test.startTest();
-        ReturnOrderProcessingService.Response response = ReturnOrderProcessingService.processReturn(request);
-        Test.stopTest();
+    Test.startTest();
+    ReturnOrderProcessingService.Response response = ReturnOrderProcessingService.processReturn(
+      request
+    );
+    Test.stopTest();
 
-        System.assertEquals(true, response.success, 'Response should indicate success.');
-        System.assertEquals('RETURN_ORDER_CREATED', response.status, 'Status should indicate creation.');
-        System.assertEquals('RO-000123', response.returnOrderNumber, 'Return order number should come from flow.');
-        System.assertEquals('00001005', response.caseNumber, 'Case number should be surfaced from the flow.');
-        System.assertEquals(
-            '返品手続きが完了しました。返品注文番号は『RO-000123』です。この番号をお控えください。担当者が確認次第、メールにてご連絡いたします。',
-            response.primaryMessage
-        );
-        System.assertEquals(null, response.secondaryMessage, 'Secondary message should be cleared.');
-        System.assertNotEquals(null, response.evaluation, 'Evaluation result should be returned.');
-        System.assertEquals(true, response.evaluation.reasonAccepted, 'Reason should have been accepted.');
+    System.assertEquals(
+      true,
+      response.success,
+      'Response should indicate success.'
+    );
+    System.assertEquals(
+      'RETURN_ORDER_CREATED',
+      response.status,
+      'Status should indicate creation.'
+    );
+    System.assertNotEquals(
+      null,
+      response.returnOrderNumber,
+      'Return order number should be returned.'
+    );
+    System.assertEquals(
+      null,
+      response.caseNumber,
+      'Case number should be empty when not created.'
+    );
+    System.assertNotEquals(
+      null,
+      response.primaryMessage,
+      'Success message should be present.'
+    );
+    System.assertEquals(
+      null,
+      response.secondaryMessage,
+      'Secondary message should be cleared.'
+    );
+    System.assertEquals(
+      true,
+      response.evaluation.reasonAccepted,
+      'Reason should have been accepted.'
+    );
+
+    ReturnOrder createdReturnOrder = [
+      SELECT Id, ReturnOrderNumber
+      FROM ReturnOrder
+      WHERE OrderId = :data.orderId
+      LIMIT 1
+    ];
+
+    System.assertEquals(
+      response.returnOrderNumber,
+      createdReturnOrder.ReturnOrderNumber,
+      'Return order number should match created record.'
+    );
+
+    List<ReturnOrderLineItem> lineItems = [
+      SELECT Id, Quantity
+      FROM ReturnOrderLineItem
+      WHERE ReturnOrderId = :createdReturnOrder.Id
+    ];
+
+    System.assertEquals(
+      1,
+      lineItems.size(),
+      'A single return order line item should be created.'
+    );
+    System.assertEquals(
+      request.quantity,
+      lineItems[0].Quantity,
+      'Line item quantity should match request.'
+    );
+
+    List<ReturnOrderLineItemAdjustment> adjustments = [
+      SELECT Id
+      FROM ReturnOrderLineItemAdjustment
+      WHERE ReturnOrderLineItemId = :lineItems[0].Id
+    ];
+
+    System.assertEquals(
+      1,
+      adjustments.size(),
+      'An adjustment record should be created.'
+    );
+
+    List<ReturnOrderLineItemTax> taxes = [
+      SELECT Id, TaxAmount
+      FROM ReturnOrderLineItemTax
+      WHERE ReturnOrderLineItemId = :lineItems[0].Id
+    ];
+
+    System.assertEquals(1, taxes.size(), 'A tax record should be created.');
+    System.assertNotEquals(
+      null,
+      taxes[0].TaxAmount,
+      'Tax amount should be populated.'
+    );
+  }
+
+  @IsTest
+  static void testProcessReturnFailureWhenOrderMissing() {
+    TestData data = TestData.setup();
+
+    ReturnOrderProcessingService.Request request = new ReturnOrderProcessingService.Request();
+    request.orderNumber = 'ORD-NOT-FOUND';
+    request.productCode = data.returnableProductCode;
+    request.quantity = 1;
+    request.returnReason = '糸のほつれがあります';
+
+    Test.startTest();
+    ReturnOrderProcessingService.Response response = ReturnOrderProcessingService.processReturn(
+      request
+    );
+    Test.stopTest();
+
+    System.assertEquals(false, response.success, 'Failure should be reported.');
+    System.assertEquals(
+      'RETURN_ORDER_FAILED',
+      response.status,
+      'Status should indicate failure.'
+    );
+    System.assertEquals(
+      null,
+      response.returnOrderNumber,
+      'Return order number should be empty.'
+    );
+    System.assertEquals(
+      null,
+      response.caseNumber,
+      'Case number should be empty when the return order fails.'
+    );
+    System.assertEquals(
+      'システムエラーにより返品手続きが完了しませんでした。お手数ですが、再度お試しください。',
+      response.primaryMessage
+    );
+    System.assertEquals(
+      '指定された注文が見つかりません。正しい注文番号を入力してください。',
+      response.secondaryMessage,
+      'Error detail should surface cause.'
+    );
+    System.assertEquals(
+      true,
+      response.evaluation.reasonAccepted,
+      'Evaluation should still indicate accepted reason.'
+    );
+
+    System.assertEquals(
+      0,
+      [SELECT COUNT() FROM ReturnOrder],
+      'No return order should be created when the order is missing.'
+    );
+  }
+
+  @IsTest
+  static void testDoesNotCreateReturnOrderWhenEvaluationRejects() {
+    TestData data = TestData.setup();
+
+    ReturnOrderProcessingService.Request request = new ReturnOrderProcessingService.Request();
+    request.orderNumber = data.orderNumber;
+    request.productCode = data.returnableProductCode;
+    request.quantity = 1;
+    request.returnReason = '不要になりました';
+
+    Test.startTest();
+    ReturnOrderProcessingService.Response response = ReturnOrderProcessingService.processReturn(
+      request
+    );
+    Test.stopTest();
+
+    System.assertEquals(
+      false,
+      response.success,
+      'Response should be unsuccessful.'
+    );
+    System.assertEquals(
+      'RETURN_REJECTED_REASON',
+      response.status,
+      'Status should come from evaluation.'
+    );
+    System.assertEquals(
+      '申し訳ございませんが、この商品の返品はポリシーによりお受けできません。',
+      response.primaryMessage
+    );
+    System.assertEquals(
+      0,
+      [SELECT COUNT() FROM ReturnOrder],
+      'Return orders should not be created when evaluation rejects the request.'
+    );
+  }
+
+  @IsTest
+  static void testValidatesInputs() {
+    TestData data = TestData.setup();
+
+    ReturnOrderProcessingService.Request missingOrder = new ReturnOrderProcessingService.Request();
+    missingOrder.productCode = data.returnableProductCode;
+    missingOrder.quantity = 1;
+    missingOrder.returnReason = '糸のほつれがあります';
+
+    try {
+      ReturnOrderProcessingService.processReturn(missingOrder);
+      System.assert(false, 'Missing order number should throw an exception.');
+    } catch (AuraHandledException e) {
+      System.assert(
+        e.getMessage().contains('注文番号'),
+        'Message should mention order number.'
+      );
     }
 
-    @IsTest
-    static void testProcessReturnFlowFailure() {
-        TestData data = TestData.setup();
-        Test.setMock(Flow.Interview.Mock.class, new FailingReturnOrderFlowMock());
+    ReturnOrderProcessingService.Request missingProduct = new ReturnOrderProcessingService.Request();
+    missingProduct.orderNumber = data.orderNumber;
+    missingProduct.quantity = 1;
+    missingProduct.returnReason = '糸のほつれがあります';
 
-        ReturnOrderProcessingService.Request request = new ReturnOrderProcessingService.Request();
-        request.orderNumber = 'ORD-20001';
-        request.productCode = data.returnableProductCode;
-        request.quantity = 1;
-        request.returnReason = '糸のほつれがあります';
-
-        Test.startTest();
-        ReturnOrderProcessingService.Response response = ReturnOrderProcessingService.processReturn(request);
-        Test.stopTest();
-
-        System.assertEquals(false, response.success, 'Failure should be reported.');
-        System.assertEquals('RETURN_ORDER_FAILED', response.status, 'Status should indicate flow failure.');
-        System.assertEquals(null, response.returnOrderNumber, 'Return order number should be empty.');
-        System.assertEquals(null, response.caseNumber, 'Case number should be empty when the flow fails.');
-        System.assertEquals(
-            'システムエラーにより返品手続きが完了しませんでした。お手数ですが、再度お試しください。',
-            response.primaryMessage
-        );
-        System.assertEquals('Flow execution failed', response.secondaryMessage, 'Error detail should surface flow error.');
-        System.assertEquals(true, response.evaluation.reasonAccepted, 'Evaluation should still indicate accepted reason.');
+    try {
+      ReturnOrderProcessingService.processReturn(missingProduct);
+      System.assert(false, 'Missing product code should throw an exception.');
+    } catch (AuraHandledException e) {
+      System.assert(
+        e.getMessage().contains('商品コード'),
+        'Message should mention product code.'
+      );
     }
 
-    @IsTest
-    static void testDoesNotInvokeFlowWhenEvaluationRejects() {
-        TestData data = TestData.setup();
-        FlowInvocationTracker.wasInvoked = false;
-        Test.setMock(Flow.Interview.Mock.class, new TrackingFlowMock());
+    ReturnOrderProcessingService.Request invalidQuantity = new ReturnOrderProcessingService.Request();
+    invalidQuantity.orderNumber = data.orderNumber;
+    invalidQuantity.productCode = data.returnableProductCode;
+    invalidQuantity.quantity = 0;
+    invalidQuantity.returnReason = '糸のほつれがあります';
 
-        ReturnOrderProcessingService.Request request = new ReturnOrderProcessingService.Request();
-        request.orderNumber = 'ORD-30001';
-        request.productCode = data.returnableProductCode;
-        request.quantity = 1;
-        request.returnReason = '不要になりました';
+    try {
+      ReturnOrderProcessingService.processReturn(invalidQuantity);
+      System.assert(false, 'Invalid quantity should throw an exception.');
+    } catch (AuraHandledException e) {
+      System.assert(
+        e.getMessage().contains('返品数量'),
+        'Message should mention quantity.'
+      );
+    }
+  }
 
-        Test.startTest();
-        ReturnOrderProcessingService.Response response = ReturnOrderProcessingService.processReturn(request);
-        Test.stopTest();
+  private class TestData {
+    Id policyId;
+    String returnableProductCode;
+    Id orderId;
+    String orderNumber;
 
-        System.assertEquals(false, response.success, 'Response should be unsuccessful.');
-        System.assertEquals('RETURN_REJECTED_REASON', response.status, 'Status should come from evaluation.');
-        System.assertEquals('申し訳ございませんが、この商品の返品はポリシーによりお受けできません。', response.primaryMessage);
-        System.assertEquals(false, FlowInvocationTracker.wasInvoked, 'Flow should not run when evaluation rejects the request.');
+    static TestData setup() {
+      TestData data = new TestData();
+      data.initialize();
+      return data;
     }
 
-    @IsTest
-    static void testValidatesInputs() {
-        TestData data = TestData.setup();
+    private void initialize() {
+      Id standardPricebookId = Test.getStandardPricebookId();
 
-        ReturnOrderProcessingService.Request missingOrder = new ReturnOrderProcessingService.Request();
-        missingOrder.productCode = data.returnableProductCode;
-        missingOrder.quantity = 1;
-        missingOrder.returnReason = '糸のほつれがあります';
+      Product2 baseProduct = new Product2(
+        Name = 'Nova Knit Cardigan',
+        ProductCode = 'NKC-001',
+        Family = 'Apparel',
+        IsActive = true
+      );
+      insert baseProduct;
 
-        try {
-            ReturnOrderProcessingService.processReturn(missingOrder);
-            System.assert(false, 'Missing order number should throw an exception.');
-        } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('注文番号'), 'Message should mention order number.');
-        }
+      PricebookEntry baseEntry = new PricebookEntry(
+        Pricebook2Id = standardPricebookId,
+        Product2Id = baseProduct.Id,
+        UnitPrice = 9800,
+        IsActive = true,
+        UseStandardPrice = false
+      );
+      insert baseEntry;
 
-        ReturnOrderProcessingService.Request missingProduct = new ReturnOrderProcessingService.Request();
-        missingProduct.orderNumber = 'ORD-40001';
-        missingProduct.quantity = 1;
-        missingProduct.returnReason = '糸のほつれがあります';
+      Account customer = new Account(Name = 'Test Customer');
+      insert customer;
 
-        try {
-            ReturnOrderProcessingService.processReturn(missingProduct);
-            System.assert(false, 'Missing product code should throw an exception.');
-        } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('商品コード'), 'Message should mention product code.');
-        }
+      Order orderRecord = new Order(
+        AccountId = customer.Id,
+        Pricebook2Id = standardPricebookId,
+        Status = getDefaultOrderStatus(),
+        EffectiveDate = Date.today()
+      );
+      insert orderRecord;
 
-        ReturnOrderProcessingService.Request invalidQuantity = new ReturnOrderProcessingService.Request();
-        invalidQuantity.orderNumber = 'ORD-40002';
-        invalidQuantity.productCode = data.returnableProductCode;
-        invalidQuantity.quantity = 0;
-        invalidQuantity.returnReason = '糸のほつれがあります';
+      OrderItem orderItemRecord = new OrderItem(
+        OrderId = orderRecord.Id,
+        Quantity = 2,
+        UnitPrice = 9800,
+        PricebookEntryId = baseEntry.Id
+      );
+      insert orderItemRecord;
 
-        try {
-            ReturnOrderProcessingService.processReturn(invalidQuantity);
-            System.assert(false, 'Invalid quantity should throw an exception.');
-        } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('返品数量'), 'Message should mention quantity.');
-        }
+      this.orderId = orderRecord.Id;
+      this.orderNumber = orderRecord.OrderNumber;
+
+      StorePolicy__c policy = new StorePolicy__c(
+        Name = 'Defective Only Return',
+        PolicyType__c = 'RETURN_DEFECTIVE_ONLY',
+        IsActive__c = true,
+        ValidFrom__c = Date.today().addDays(-30),
+        ValidTo__c = Date.today().addDays(30),
+        Description__c = '不良品のみ返品可能です。'
+      );
+      insert policy;
+      this.policyId = policy.Id;
+
+      StorePolicyProduct__c mapping = new StorePolicyProduct__c(
+        Product__c = baseProduct.Id,
+        StorePolicy__c = policy.Id,
+        IsActive__c = true
+      );
+      insert mapping;
+
+      Product2 variation = new Product2(
+        Name = 'Nova Knit Cardigan - Blue',
+        ProductCode = 'NKC-001-BL',
+        Family = 'Apparel',
+        IsActive = true
+      );
+      insert variation;
+
+      PricebookEntry variationEntry = new PricebookEntry(
+        Pricebook2Id = standardPricebookId,
+        Product2Id = variation.Id,
+        UnitPrice = 9800,
+        IsActive = true,
+        UseStandardPrice = false
+      );
+      insert variationEntry;
+
+      Product2 alternative1 = new Product2(
+        Name = 'Nova Knit Sweater',
+        ProductCode = 'NKS-100',
+        Family = 'Apparel',
+        IsActive = true
+      );
+      insert alternative1;
+
+      PricebookEntry alternativeEntry1 = new PricebookEntry(
+        Pricebook2Id = standardPricebookId,
+        Product2Id = alternative1.Id,
+        UnitPrice = 9500,
+        IsActive = true,
+        UseStandardPrice = false
+      );
+      insert alternativeEntry1;
+
+      Product2 alternative2 = new Product2(
+        Name = 'Nova Knit Hoodie',
+        ProductCode = 'NKH-200',
+        Family = 'Apparel',
+        IsActive = true
+      );
+      insert alternative2;
+
+      PricebookEntry alternativeEntry2 = new PricebookEntry(
+        Pricebook2Id = standardPricebookId,
+        Product2Id = alternative2.Id,
+        UnitPrice = 9900,
+        IsActive = true,
+        UseStandardPrice = false
+      );
+      insert alternativeEntry2;
+
+      this.returnableProductCode = baseProduct.ProductCode;
     }
 
-    private class TestData {
-        Id policyId;
-        String returnableProductCode;
-
-        static TestData setup() {
-            TestData data = new TestData();
-            data.initialize();
-            return data;
+    private String getDefaultOrderStatus() {
+      Schema.DescribeFieldResult statusField = Schema.sObjectType.Order.fields.Status.getDescribe();
+      for (Schema.PicklistEntry entry : statusField.getPicklistValues()) {
+        if (entry.isDefaultValue() && entry.isActive()) {
+          return entry.getValue();
         }
+      }
 
-        private void initialize() {
-            Id standardPricebookId = Test.getStandardPricebookId();
-
-            Product2 baseProduct = new Product2(
-                Name = 'Nova Knit Cardigan',
-                ProductCode = 'NKC-001',
-                Family = 'Apparel',
-                IsActive = true
-            );
-            insert baseProduct;
-
-            PricebookEntry baseEntry = new PricebookEntry(
-                Pricebook2Id = standardPricebookId,
-                Product2Id = baseProduct.Id,
-                UnitPrice = 9800,
-                IsActive = true,
-                UseStandardPrice = false
-            );
-            insert baseEntry;
-
-            StorePolicy__c policy = new StorePolicy__c(
-                Name = 'Defective Only Return',
-                PolicyType__c = 'RETURN_DEFECTIVE_ONLY',
-                IsActive__c = true,
-                ValidFrom__c = Date.today().addDays(-30),
-                ValidTo__c = Date.today().addDays(30),
-                Description__c = '不良品のみ返品可能です。'
-            );
-            insert policy;
-            this.policyId = policy.Id;
-
-            StorePolicyProduct__c mapping = new StorePolicyProduct__c(
-                Product__c = baseProduct.Id,
-                StorePolicy__c = policy.Id,
-                IsActive__c = true
-            );
-            insert mapping;
-
-            Product2 variation = new Product2(
-                Name = 'Nova Knit Cardigan - Blue',
-                ProductCode = 'NKC-001-BL',
-                Family = 'Apparel',
-                IsActive = true
-            );
-            insert variation;
-
-            PricebookEntry variationEntry = new PricebookEntry(
-                Pricebook2Id = standardPricebookId,
-                Product2Id = variation.Id,
-                UnitPrice = 9800,
-                IsActive = true,
-                UseStandardPrice = false
-            );
-            insert variationEntry;
-
-            Product2 alternative1 = new Product2(
-                Name = 'Nova Knit Sweater',
-                ProductCode = 'NKS-100',
-                Family = 'Apparel',
-                IsActive = true
-            );
-            insert alternative1;
-
-            PricebookEntry alternativeEntry1 = new PricebookEntry(
-                Pricebook2Id = standardPricebookId,
-                Product2Id = alternative1.Id,
-                UnitPrice = 9500,
-                IsActive = true,
-                UseStandardPrice = false
-            );
-            insert alternativeEntry1;
-
-            Product2 alternative2 = new Product2(
-                Name = 'Nova Knit Hoodie',
-                ProductCode = 'NKH-200',
-                Family = 'Apparel',
-                IsActive = true
-            );
-            insert alternative2;
-
-            PricebookEntry alternativeEntry2 = new PricebookEntry(
-                Pricebook2Id = standardPricebookId,
-                Product2Id = alternative2.Id,
-                UnitPrice = 9900,
-                IsActive = true,
-                UseStandardPrice = false
-            );
-            insert alternativeEntry2;
-
-            this.returnableProductCode = baseProduct.ProductCode;
+      for (Schema.PicklistEntry entry : statusField.getPicklistValues()) {
+        if (entry.isActive()) {
+          return entry.getValue();
         }
+      }
+
+      return 'Draft';
     }
-
-    private class SuccessfulReturnOrderFlowMock implements Flow.Interview.Mock {
-        public Map<String, Object> start(Map<String, Object> inputs) {
-            System.assertEquals('ORD-10001', (String) inputs.get('OrderNumber'));
-            System.assertEquals('NKC-001', (String) inputs.get('ProductCode'));
-            System.assertEquals(Decimal.valueOf('1'), (Decimal) inputs.get('Quantity'));
-            System.assertEquals('糸のほつれがありました', (String) inputs.get('ReturnReason'));
-
-            return new Map<String, Object>{
-                'varReturnOrderNumber' => 'RO-000123',
-                'varCaseNumber' => '00001005'
-            };
-        }
-
-        public Map<String, Object> resume(Map<String, Object> inputs) {
-            return null;
-        }
-    }
-
-    private class FailingReturnOrderFlowMock implements Flow.Interview.Mock {
-        public Map<String, Object> start(Map<String, Object> inputs) {
-            throw new AuraHandledException('Flow execution failed');
-        }
-
-        public Map<String, Object> resume(Map<String, Object> inputs) {
-            return null;
-        }
-    }
-
-    private class TrackingFlowMock implements Flow.Interview.Mock {
-        public Map<String, Object> start(Map<String, Object> inputs) {
-            FlowInvocationTracker.wasInvoked = true;
-            return new Map<String, Object>();
-        }
-
-        public Map<String, Object> resume(Map<String, Object> inputs) {
-            return null;
-        }
-    }
-
-    private class FlowInvocationTracker {
-        static Boolean wasInvoked = false;
-    }
+  }
 }


### PR DESCRIPTION
## Summary
- replace the ReturnOrder flow invocation with direct Apex logic that builds return orders, line items, adjustments, and taxes
- add reusable helpers to populate required field defaults when composing dynamic return order records
- update the ReturnOrderProcessingService tests to provision order data and verify the created return order structures

## Testing
- Not run (Salesforce CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_690550963f48832cbebb5172e3b04938