### PR TITLE
refactor: accept string product identifier in return requests

### DIFF
--- a/force-app/main/default/classes/ReturnOrderProcessingService.cls
+++ b/force-app/main/default/classes/ReturnOrderProcessingService.cls
@@ -6,7 +6,7 @@ public with sharing class ReturnOrderProcessingService {
 
     @AuraEnabled
     @InvocableVariable
-    public String productCode;
+    public String productIdentifier;
 
     @AuraEnabled
     @InvocableVariable
@@ -65,18 +65,27 @@ public with sharing class ReturnOrderProcessingService {
     String normalizedOrderNumber = request.orderNumber != null
       ? request.orderNumber.trim()
       : null;
-    String normalizedProductIdentifier = request.productCode != null
-      ? request.productCode.trim()
-      : null;
+    String normalizedProductIdentifier = normalizeProductIdentifier(
+      request.productIdentifier
+    );
+    Product2 resolvedProduct = findProductRecord(normalizedProductIdentifier);
+    String resolvedProductIdentifier = resolveProductIdentifier(
+      normalizedProductIdentifier,
+      resolvedProduct
+    );
     String normalizedReturnReason = request.returnReason != null
       ? request.returnReason.trim()
       : null;
     Decimal quantity = request.quantity;
 
-    validateInputs(normalizedOrderNumber, normalizedProductIdentifier, quantity);
+    validateInputs(
+      normalizedOrderNumber,
+      resolvedProductIdentifier,
+      quantity
+    );
 
     ReturnEligibilityService.EvaluationResult evaluation = ReturnEligibilityService.evaluateProductReturn(
-      normalizedProductIdentifier,
+      resolvedProductIdentifier,
       normalizedReturnReason
     );
 
@@ -104,7 +113,8 @@ public with sharing class ReturnOrderProcessingService {
 
     ReturnOrderOutcome outcome = createReturnOrder(
       normalizedOrderNumber,
-      normalizedProductIdentifier,
+      resolvedProductIdentifier,
+      resolvedProduct != null ? resolvedProduct.Id : null,
       quantity,
       normalizedReturnReason
     );
@@ -173,6 +183,41 @@ public with sharing class ReturnOrderProcessingService {
     }
   }
 
+  private static String normalizeProductIdentifier(String input) {
+    return String.isBlank(input) ? null : input.trim();
+  }
+
+  private static Product2 findProductRecord(String identifier) {
+    if (String.isBlank(identifier)) {
+      return null;
+    }
+
+    List<Product2> products = [
+      SELECT Id, Name, ProductCode
+      FROM Product2
+      WHERE IsActive = TRUE AND (ProductCode = :identifier OR Name = :identifier)
+      LIMIT 1
+    ];
+
+    return products.isEmpty() ? null : products[0];
+  }
+
+  private static String resolveProductIdentifier(
+    String identifier,
+    Product2 productRecord
+  ) {
+    if (productRecord != null) {
+      if (!String.isBlank(productRecord.ProductCode)) {
+        return productRecord.ProductCode;
+      }
+      if (!String.isBlank(productRecord.Name)) {
+        return productRecord.Name;
+      }
+    }
+
+    return identifier;
+  }
+
   private static String buildSuccessMessage(String returnOrderNumber) {
     String number = String.isBlank(returnOrderNumber)
       ? '不明'
@@ -185,6 +230,7 @@ public with sharing class ReturnOrderProcessingService {
   private static ReturnOrderOutcome createReturnOrder(
     String orderNumber,
     String productIdentifier,
+    Id productId,
     Decimal quantity,
     String returnReason
   ) {
@@ -203,7 +249,8 @@ public with sharing class ReturnOrderProcessingService {
 
     OrderItem orderItemRecord = findOrderItem(
       orderRecord.Id,
-      productIdentifier
+      productIdentifier,
+      productId
     );
     if (orderItemRecord == null) {
       outcome.errorMessage = '指定された商品はこの注文に含まれていません。';
@@ -266,9 +313,34 @@ public with sharing class ReturnOrderProcessingService {
 
   private static OrderItem findOrderItem(
     Id orderId,
-    String productIdentifier
+    String productIdentifier,
+    Id productId
   ) {
-    if (orderId == null || String.isBlank(productIdentifier)) {
+    if (orderId == null) {
+      return null;
+    }
+
+    if (productId != null) {
+      List<OrderItem> itemsByProduct = [
+        SELECT
+          Id,
+          Quantity,
+          UnitPrice,
+          PricebookEntryId,
+          Product2Id,
+          Product2.ProductCode,
+          Product2.Name
+        FROM OrderItem
+        WHERE OrderId = :orderId AND Product2Id = :productId
+        LIMIT 1
+      ];
+
+      if (!itemsByProduct.isEmpty()) {
+        return itemsByProduct[0];
+      }
+    }
+
+    if (String.isBlank(productIdentifier)) {
       return null;
     }
 

--- a/force-app/main/default/classes/ReturnOrderProcessingServiceTest.cls
+++ b/force-app/main/default/classes/ReturnOrderProcessingServiceTest.cls
@@ -6,7 +6,7 @@ private class ReturnOrderProcessingServiceTest {
 
     ReturnOrderProcessingService.Request request = new ReturnOrderProcessingService.Request();
     request.orderNumber = data.orderNumber;
-    request.productCode = data.returnableProductCode;
+    request.productIdentifier = data.returnableProductCode;
     request.quantity = 1;
     request.returnReason = '  糸のほつれがありました  ';
 
@@ -114,7 +114,7 @@ private class ReturnOrderProcessingServiceTest {
 
     ReturnOrderProcessingService.Request request = new ReturnOrderProcessingService.Request();
     request.orderNumber = data.orderNumber;
-    request.productCode = data.returnableProductName;
+    request.productIdentifier = data.returnableProductName;
     request.quantity = 1;
     request.returnReason = '  糸のほつれがありました  ';
 
@@ -156,7 +156,7 @@ private class ReturnOrderProcessingServiceTest {
 
     ReturnOrderProcessingService.Request request = new ReturnOrderProcessingService.Request();
     request.orderNumber = data.orderNumber;
-    request.productCode = data.returnableProductCode;
+    request.productIdentifier = data.returnableProductCode;
     request.quantity = 1;
     request.returnReason = '糸のほつれがありました';
 
@@ -181,7 +181,7 @@ private class ReturnOrderProcessingServiceTest {
 
     ReturnOrderProcessingService.Request request = new ReturnOrderProcessingService.Request();
     request.orderNumber = 'ORD-NOT-FOUND';
-    request.productCode = data.returnableProductCode;
+    request.productIdentifier = data.returnableProductCode;
     request.quantity = 1;
     request.returnReason = '糸のほつれがあります';
 
@@ -235,7 +235,7 @@ private class ReturnOrderProcessingServiceTest {
 
     ReturnOrderProcessingService.Request request = new ReturnOrderProcessingService.Request();
     request.orderNumber = data.orderNumber;
-    request.productCode = data.returnableProductCode;
+    request.productIdentifier = data.returnableProductCode;
     request.quantity = 1;
     request.returnReason = '不要になりました';
 
@@ -271,7 +271,7 @@ private class ReturnOrderProcessingServiceTest {
     TestData data = TestData.setup();
 
     ReturnOrderProcessingService.Request missingOrder = new ReturnOrderProcessingService.Request();
-    missingOrder.productCode = data.returnableProductCode;
+    missingOrder.productIdentifier = data.returnableProductCode;
     missingOrder.quantity = 1;
     missingOrder.returnReason = '糸のほつれがあります';
 
@@ -302,7 +302,7 @@ private class ReturnOrderProcessingServiceTest {
 
     ReturnOrderProcessingService.Request invalidQuantity = new ReturnOrderProcessingService.Request();
     invalidQuantity.orderNumber = data.orderNumber;
-    invalidQuantity.productCode = data.returnableProductCode;
+    invalidQuantity.productIdentifier = data.returnableProductCode;
     invalidQuantity.quantity = 0;
     invalidQuantity.returnReason = '糸のほつれがあります';
 


### PR DESCRIPTION
## Summary
- replace the flow request product wrapper with a single string identifier
- trim and resolve the identifier against Product2 code or name before validation and order creation
- update unit tests to send the identifier string and continue covering code and name paths

## Testing
- not run (Salesforce Apex tests require a Salesforce org)


------
https://chatgpt.com/codex/tasks/task_e_6905620cbc54832cb4207de7a09f6296