### PR TITLE
Return error responses from ReturnOrderProcessingService

### DIFF
--- a/force-app/main/default/classes/ReturnOrderProcessingService.cls
+++ b/force-app/main/default/classes/ReturnOrderProcessingService.cls
@@ -55,11 +55,29 @@ public with sharing class ReturnOrderProcessingService {
     String errorMessage;
   }
 
+  private static Response buildErrorResponse(
+    String status,
+    String primaryMessage,
+    String secondaryMessage
+  ) {
+    Response response = new Response();
+    response.success = false;
+    response.status = status;
+    response.primaryMessage = primaryMessage;
+    response.secondaryMessage = secondaryMessage;
+    response.returnOrderNumber = null;
+    response.caseNumber = null;
+    response.evaluation = null;
+    return response;
+  }
+
   @AuraEnabled
   public static Response processReturn(Request request) {
     if (request == null) {
-      throw new AuraHandledException(
-        '返品手続きを進めるには注文情報が必要です。'
+      return buildErrorResponse(
+        'INVALID_REQUEST',
+        '返品手続きを進めるには注文情報が必要です。',
+        null
       );
     }
 
@@ -79,11 +97,15 @@ public with sharing class ReturnOrderProcessingService {
       : null;
     Decimal quantity = request.quantity;
 
-    validateInputs(
+    String validationError = validateInputs(
       normalizedOrderNumber,
       resolvedProductIdentifier,
       quantity
     );
+
+    if (validationError != null) {
+      return buildErrorResponse('INVALID_INPUT', validationError, null);
+    }
 
     ReturnEligibilityService.EvaluationResult evaluation = ReturnEligibilityService.evaluateProductReturn(
       resolvedProductIdentifier,
@@ -144,9 +166,13 @@ public with sharing class ReturnOrderProcessingService {
   )
   public static List<Response> processReturnFromFlow(List<Request> requests) {
     if (requests == null || requests.isEmpty()) {
-      throw new AuraHandledException(
-        '返品手続きを進めるには注文情報が必要です。'
-      );
+      return new List<Response>{
+        buildErrorResponse(
+          'INVALID_REQUEST',
+          '返品手続きを進めるには注文情報が必要です。',
+          null
+        )
+      };
     }
 
     List<Response> responses = new List<Response>();
@@ -157,28 +183,24 @@ public with sharing class ReturnOrderProcessingService {
     return responses;
   }
 
-  private static void validateInputs(
+  private static String validateInputs(
     String orderNumber,
     String productIdentifier,
     Decimal quantity
   ) {
     if (String.isBlank(orderNumber)) {
-      throw new AuraHandledException(
-        '返品手続きを進めるには注文番号が必要です。'
-      );
+      return '返品手続きを進めるには注文番号が必要です。';
     }
 
-    if (!String.isBlank(productIdentifier)) {
-      throw new AuraHandledException(
-        '返品手続きを進めるには商品情報が必要です。'
-      );
+    if (String.isBlank(productIdentifier)) {
+      return '返品手続きを進めるには商品情報が必要です。';
     }
 
     if (quantity == null || quantity <= 0) {
-      throw new AuraHandledException(
-        '返品数量は1以上の数値を指定してください。'
-      );
+      return '返品数量は1以上の数値を指定してください。';
     }
+
+    return null;
   }
 
   private static String normalizeProductIdentifier(String input) {
@@ -256,15 +278,26 @@ public with sharing class ReturnOrderProcessingService {
     }
 
     try {
-      SObject returnOrder = buildReturnOrderRecord(orderRecord, returnReason);
+      SObject returnOrder = buildReturnOrderRecord(
+        orderRecord,
+        returnReason,
+        outcome
+      );
+      if (returnOrder == null) {
+        return outcome;
+      }
       insert returnOrder;
 
       SObject returnOrderLineItem = buildReturnOrderLineItem(
         returnOrder,
         orderItemRecord,
         quantity,
-        returnReason
+        returnReason,
+        outcome
       );
+      if (returnOrderLineItem == null) {
+        return outcome;
+      }
       insert returnOrderLineItem;
 
       SObject adjustment = buildReturnOrderLineItemAdjustment(
@@ -292,6 +325,16 @@ public with sharing class ReturnOrderProcessingService {
     }
 
     return outcome;
+  }
+
+  private static void setOutcomeError(
+    ReturnOrderOutcome outcome,
+    String message
+  ) {
+    if (outcome == null || !String.isBlank(outcome.errorMessage)) {
+      return;
+    }
+    outcome.errorMessage = message;
   }
 
   private static Order findOrder(String orderNumber) {
@@ -364,18 +407,22 @@ public with sharing class ReturnOrderProcessingService {
 
   private static SObject buildReturnOrderRecord(
     Order orderRecord,
-    String returnReason
+    String returnReason,
+    ReturnOrderOutcome outcome
   ) {
     Schema.SObjectType typeInfo = Schema.getGlobalDescribe().get('ReturnOrder');
     if (typeInfo == null) {
-      throw new AuraHandledException(
+      setOutcomeError(
+        outcome,
         'Return Order オブジェクトが組織で利用できません。'
       );
+      return null;
     }
 
     Schema.DescribeSObjectResult describe = typeInfo.getDescribe();
     if (!describe.isCreateable()) {
-      throw new AuraHandledException('Return Order の作成権限がありません。');
+      setOutcomeError(outcome, 'Return Order の作成権限がありません。');
+      return null;
     }
 
     SObject record = typeInfo.newSObject();
@@ -394,21 +441,26 @@ public with sharing class ReturnOrderProcessingService {
     SObject returnOrder,
     OrderItem orderItem,
     Decimal quantity,
-    String returnReason
+    String returnReason,
+    ReturnOrderOutcome outcome
   ) {
     Schema.SObjectType typeInfo = Schema.getGlobalDescribe()
       .get('ReturnOrderLineItem');
     if (typeInfo == null) {
-      throw new AuraHandledException(
+      setOutcomeError(
+        outcome,
         'Return Order Line Item オブジェクトが組織で利用できません。'
       );
+      return null;
     }
 
     Schema.DescribeSObjectResult describe = typeInfo.getDescribe();
     if (!describe.isCreateable()) {
-      throw new AuraHandledException(
+      setOutcomeError(
+        outcome,
         'Return Order Line Item の作成権限がありません。'
       );
+      return null;
     }
 
     SObject record = typeInfo.newSObject();

--- a/force-app/main/default/classes/ReturnOrderProcessingServiceTest.cls
+++ b/force-app/main/default/classes/ReturnOrderProcessingServiceTest.cls
@@ -275,30 +275,40 @@ private class ReturnOrderProcessingServiceTest {
     missingOrder.quantity = 1;
     missingOrder.returnReason = '糸のほつれがあります';
 
-    try {
-      ReturnOrderProcessingService.processReturn(missingOrder);
-      System.assert(false, 'Missing order number should throw an exception.');
-    } catch (AuraHandledException e) {
-      System.assert(
-        e.getMessage().contains('注文番号'),
-        'Message should mention order number.'
-      );
-    }
+    ReturnOrderProcessingService.Response missingOrderResponse = ReturnOrderProcessingService.processReturn(
+      missingOrder
+    );
+    System.assertEquals(false, missingOrderResponse.success, 'Missing order should fail.');
+    System.assertEquals(
+      'INVALID_INPUT',
+      missingOrderResponse.status,
+      'Status should indicate invalid input.'
+    );
+    System.assertEquals(
+      '返品手続きを進めるには注文番号が必要です。',
+      missingOrderResponse.primaryMessage,
+      'Primary message should mention the order number.'
+    );
 
     ReturnOrderProcessingService.Request missingProduct = new ReturnOrderProcessingService.Request();
     missingProduct.orderNumber = data.orderNumber;
     missingProduct.quantity = 1;
     missingProduct.returnReason = '糸のほつれがあります';
 
-    try {
-      ReturnOrderProcessingService.processReturn(missingProduct);
-      System.assert(false, 'Missing product code should throw an exception.');
-    } catch (AuraHandledException e) {
-      System.assert(
-        e.getMessage().contains('商品情報'),
-        'Message should mention product identifier.'
-      );
-    }
+    ReturnOrderProcessingService.Response missingProductResponse = ReturnOrderProcessingService.processReturn(
+      missingProduct
+    );
+    System.assertEquals(false, missingProductResponse.success, 'Missing product should fail.');
+    System.assertEquals(
+      'INVALID_INPUT',
+      missingProductResponse.status,
+      'Status should indicate invalid input.'
+    );
+    System.assertEquals(
+      '返品手続きを進めるには商品情報が必要です。',
+      missingProductResponse.primaryMessage,
+      'Primary message should mention the product information.'
+    );
 
     ReturnOrderProcessingService.Request invalidQuantity = new ReturnOrderProcessingService.Request();
     invalidQuantity.orderNumber = data.orderNumber;
@@ -306,15 +316,20 @@ private class ReturnOrderProcessingServiceTest {
     invalidQuantity.quantity = 0;
     invalidQuantity.returnReason = '糸のほつれがあります';
 
-    try {
-      ReturnOrderProcessingService.processReturn(invalidQuantity);
-      System.assert(false, 'Invalid quantity should throw an exception.');
-    } catch (AuraHandledException e) {
-      System.assert(
-        e.getMessage().contains('返品数量'),
-        'Message should mention quantity.'
-      );
-    }
+    ReturnOrderProcessingService.Response invalidQuantityResponse = ReturnOrderProcessingService.processReturn(
+      invalidQuantity
+    );
+    System.assertEquals(false, invalidQuantityResponse.success, 'Invalid quantity should fail.');
+    System.assertEquals(
+      'INVALID_INPUT',
+      invalidQuantityResponse.status,
+      'Status should indicate invalid input.'
+    );
+    System.assertEquals(
+      '返品数量は1以上の数値を指定してください。',
+      invalidQuantityResponse.primaryMessage,
+      'Primary message should mention quantity.'
+    );
   }
 
   private static ReturnOrderProcessingService.ProductInformation buildProductInfo(


### PR DESCRIPTION
## Summary
- return structured error responses from `ReturnOrderProcessingService` instead of throwing `AuraHandledException`
- surface schema and validation issues through the response payload for Flow consumption
- update Apex tests to assert the new error handling contract

## Testing
- not run (Apex tests require a Salesforce org)


------
https://chatgpt.com/codex/tasks/task_e_690582bf22ec832ca24aea3b9ff97db6