### PR TITLE
Refetch return order number by Id

### DIFF
--- a/force-app/main/default/classes/ReturnOrderProcessingService.cls
+++ b/force-app/main/default/classes/ReturnOrderProcessingService.cls
@@ -708,6 +708,27 @@ public with sharing class ReturnOrderProcessingService {
       }
     }
 
+    Id returnOrderId = (Id) returnOrder.get('Id');
+    if (returnOrderId != null) {
+      List<ReturnOrder> queriedReturnOrders = [
+        SELECT ReturnOrderNumber, Name
+        FROM ReturnOrder
+        WHERE Id = :returnOrderId
+        LIMIT 1
+      ];
+
+      if (!queriedReturnOrders.isEmpty()) {
+        ReturnOrder queriedReturnOrder = queriedReturnOrders[0];
+        if (!String.isBlank(queriedReturnOrder.ReturnOrderNumber)) {
+          return queriedReturnOrder.ReturnOrderNumber;
+        }
+
+        if (!String.isBlank(queriedReturnOrder.Name)) {
+          return queriedReturnOrder.Name;
+        }
+      }
+    }
+
     if (
       returnOrder.getSObjectType()
         .getDescribe()
@@ -720,6 +741,6 @@ public with sharing class ReturnOrderProcessingService {
       }
     }
 
-    return (String) returnOrder.get('Id');
+    return returnOrderId != null ? (String) returnOrderId : null;
   }
 }


### PR DESCRIPTION
## Summary
- requery the ReturnOrder record by Id to reliably access the ReturnOrderNumber field
- keep existing fallbacks to Name and Id when the number cannot be retrieved

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690616daebd0832c87ca136e214b8a70