### PR TITLE
feat: allow agentforce payload overrides

### DIFF
--- a/force-app/main/default/classes/AgentforceChatController.cls
+++ b/force-app/main/default/classes/AgentforceChatController.cls
@@ -122,6 +122,11 @@ public with sharing class AgentforceChatController {
       'message' => messagePayload,
       'variables' => new List<Object>()
     };
+
+    applyConfiguredPayloadOverrides(
+      payload,
+      config != null ? config.Send_Message_Parameters__c : null
+    );
     request.setBody(JSON.serialize(payload));
 
     Http http = new Http();
@@ -267,13 +272,20 @@ public with sharing class AgentforceChatController {
       : new Map<String, Object>();
     applyDefaultStartSessionPayload(payloadToSend);
 
+    applyConfiguredPayloadOverrides(
+      payloadToSend,
+      config != null ? config.Start_Session_Parameters__c : null
+    );
+
     String sessionKeyFromPayload = payloadToSend.containsKey(
         'externalSessionKey'
       ) && payloadToSend.get('externalSessionKey') instanceof String
       ? (String) payloadToSend.get('externalSessionKey')
       : null;
 
-    System.debug('Agentforce start session payload: ' + JSON.serialize(payloadToSend));
+    System.debug(
+      'Agentforce start session payload: ' + JSON.serialize(payloadToSend)
+    );
     request.setBody(JSON.serialize(payloadToSend));
 
     Http http = new Http();
@@ -446,7 +458,8 @@ public with sharing class AgentforceChatController {
       try {
         instanceConfig.put(
           'endpoint',
-          'https://orgfarm-ba397eacea-dev-ed.develop.my.salesforce.com');
+          'https://orgfarm-ba397eacea-dev-ed.develop.my.salesforce.com'
+        );
       } catch (Exception ex) {
         // If the base URL cannot be resolved we leave the endpoint unset.
       }
@@ -517,6 +530,52 @@ public with sharing class AgentforceChatController {
       streamingCapabilities.put('chunkTypes', new List<Object>{ 'Text' });
     }
     payload.put('streamingCapabilities', streamingCapabilities);
+  }
+
+  private static void applyConfiguredPayloadOverrides(
+    Map<String, Object> payload,
+    String overridesJson
+  ) {
+    if (payload == null || String.isBlank(overridesJson)) {
+      return;
+    }
+
+    try {
+      Object parsed = JSON.deserializeUntyped(overridesJson);
+      if (parsed instanceof Map<String, Object>) {
+        mergeObjectMaps(payload, (Map<String, Object>) parsed);
+      }
+    } catch (Exception ex) {
+      System.debug(
+        LoggingLevel.WARN,
+        'Agentforce payload override parsing failed: ' + ex.getMessage()
+      );
+    }
+  }
+
+  private static void mergeObjectMaps(
+    Map<String, Object> target,
+    Map<String, Object> overrides
+  ) {
+    if (target == null || overrides == null) {
+      return;
+    }
+
+    for (String key : overrides.keySet()) {
+      Object overrideValue = overrides.get(key);
+      if (
+        target.containsKey(key) &&
+        target.get(key) instanceof Map<String, Object> &&
+        overrideValue instanceof Map<String, Object>
+      ) {
+        mergeObjectMaps(
+          (Map<String, Object>) target.get(key),
+          (Map<String, Object>) overrideValue
+        );
+      } else {
+        target.put(key, overrideValue);
+      }
+    }
   }
 
   private static void enrichStartSessionResult(

--- a/force-app/main/default/classes/AgentforceChatControllerTest.cls
+++ b/force-app/main/default/classes/AgentforceChatControllerTest.cls
@@ -1,0 +1,153 @@
+@IsTest
+private class AgentforceChatControllerTest {
+  private class RecordingHttpCalloutMock implements HttpCalloutMock {
+    private List<HttpResponse> responses;
+    public List<HttpRequest> requests = new List<HttpRequest>();
+    private Integer index = 0;
+
+    RecordingHttpCalloutMock(List<HttpResponse> responses) {
+      this.responses = responses;
+    }
+
+    public HTTPResponse respond(HTTPRequest req) {
+      requests.add(req);
+      if (responses.isEmpty()) {
+        HttpResponse emptyResponse = new HttpResponse();
+        emptyResponse.setStatusCode(200);
+        return emptyResponse;
+      }
+      if (index >= responses.size()) {
+        return responses[responses.size() - 1];
+      }
+      return responses[index++];
+    }
+  }
+
+  @IsTest
+  static void startSessionIncludesConfiguredOverrides() {
+    Test.setCustomMetadata(
+      Agentforce_Config__mdt.SObjectType,
+      'Default',
+      new Map<String, Object>{
+        'DeveloperName' => 'Default',
+        'MasterLabel' => 'Default',
+        'Bot_Id__c' => 'test-bot',
+        'Endpoint_Url__c' => 'https://example.com/oauth/token',
+        'Start_Session_Endpoint_Url__c' => 'https://example.com/agents/{0}/sessions',
+        'Messages_Endpoint_Url__c' => 'https://example.com/sessions/{0}/messages',
+        'Chat_Endpoint_Url__c' => 'https://example.com/agentforce',
+        'Consumer_Key__c' => 'client-id',
+        'Consumer_Secret__c' => 'client-secret',
+        'Start_Session_Parameters__c' => '{"context":{"origin":"AgentforceBuilder"},"sessionConfig":{"mode":"Debug"}}'
+      }
+    );
+
+    HttpResponse tokenResponse = buildJsonResponse(
+      200,
+      '{"access_token":"token-123"}'
+    );
+    HttpResponse startSessionResponse = buildJsonResponse(
+      200,
+      '{"sessionId":"session-1","messagesUrl":"https://example.com/sessions/session-1/messages"}'
+    );
+
+    RecordingHttpCalloutMock mock = new RecordingHttpCalloutMock(
+      new List<HttpResponse>{ tokenResponse, startSessionResponse }
+    );
+    Test.setMock(HttpCalloutMock.class, mock);
+
+    Test.startTest();
+    AgentforceChatController.AgentforceStartSessionResult result = AgentforceChatController.startSession(
+      null,
+      new Map<String, Object>{}
+    );
+    Test.stopTest();
+
+    System.assertEquals('session-1', result.sessionId);
+    System.assertEquals(2, mock.requests.size());
+
+    HttpRequest startRequest = mock.requests[1];
+    Map<String, Object> payload = (Map<String, Object>) JSON.deserializeUntyped(
+      startRequest.getBody()
+    );
+    System.assertEquals(
+      'AgentforceBuilder',
+      ((Map<String, Object>) payload.get('context')).get('origin')
+    );
+    System.assertEquals(
+      'Debug',
+      ((Map<String, Object>) payload.get('sessionConfig')).get('mode')
+    );
+    System.assert(payload.containsKey('externalSessionKey'));
+  }
+
+  @IsTest
+  static void sendMessageIncludesConfiguredOverrides() {
+    Test.setCustomMetadata(
+      Agentforce_Config__mdt.SObjectType,
+      'Default',
+      new Map<String, Object>{
+        'DeveloperName' => 'Default',
+        'MasterLabel' => 'Default',
+        'Bot_Id__c' => 'test-bot',
+        'Endpoint_Url__c' => 'https://example.com/oauth/token',
+        'Start_Session_Endpoint_Url__c' => 'https://example.com/agents/{0}/sessions',
+        'Messages_Endpoint_Url__c' => 'https://example.com/sessions/{sessionId}/messages',
+        'Chat_Endpoint_Url__c' => 'https://example.com/agentforce',
+        'Consumer_Key__c' => 'client-id',
+        'Consumer_Secret__c' => 'client-secret',
+        'Send_Message_Parameters__c' => '{"metadata":{"origin":"AgentforceBuilder"},"message":{"mode":"Debug"}}'
+      }
+    );
+
+    HttpResponse tokenResponse = buildJsonResponse(
+      200,
+      '{"access_token":"token-123"}'
+    );
+    HttpResponse messageResponse = buildJsonResponse(
+      200,
+      '{"messages":[{"type":"Inform","message":"Hello"}]}'
+    );
+
+    RecordingHttpCalloutMock mock = new RecordingHttpCalloutMock(
+      new List<HttpResponse>{ tokenResponse, messageResponse }
+    );
+    Test.setMock(HttpCalloutMock.class, mock);
+
+    Test.startTest();
+    AgentforceChatController.sendMessage(
+      'Hi',
+      new List<AgentforceChatController.AgentforceChatTranscriptEntry>(),
+      null,
+      null,
+      'session-abc'
+    );
+    Test.stopTest();
+
+    System.assertEquals(2, mock.requests.size());
+    HttpRequest messageRequest = mock.requests[1];
+    Map<String, Object> payload = (Map<String, Object>) JSON.deserializeUntyped(
+      messageRequest.getBody()
+    );
+    System.assertEquals(
+      'AgentforceBuilder',
+      ((Map<String, Object>) payload.get('metadata')).get('origin')
+    );
+    Map<String, Object> messageSection = (Map<String, Object>) payload.get(
+      'message'
+    );
+    System.assertEquals('Debug', messageSection.get('mode'));
+    System.assertEquals('Hi', messageSection.get('text'));
+  }
+
+  private static HttpResponse buildJsonResponse(
+    Integer statusCode,
+    String body
+  ) {
+    HttpResponse response = new HttpResponse();
+    response.setStatusCode(statusCode);
+    response.setBody(body);
+    response.setHeader('Content-Type', 'application/json');
+    return response;
+  }
+}

--- a/force-app/main/default/classes/AgentforceChatControllerTest.cls-meta.xml
+++ b/force-app/main/default/classes/AgentforceChatControllerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/customMetadata/Agentforce_Config.Default.md-meta.xml
+++ b/force-app/main/default/customMetadata/Agentforce_Config.Default.md-meta.xml
@@ -1,49 +1,107 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata">
     <label>Default</label>
     <protected>false</protected>
     <values>
         <field>Bot_Id__c</field>
-        <value xsi:type="xsd:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">demo-bot</value>
+        <value
+      xsi:type="xsd:string"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    >demo-bot</value>
     </values>
     <values>
         <field>Endpoint_Url__c</field>
-        <value xsi:type="xsd:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">https://example.com/oauth/token</value>
+        <value
+      xsi:type="xsd:string"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    >https://example.com/oauth/token</value>
     </values>
     <values>
         <field>Start_Session_Endpoint_Url__c</field>
-        <value xsi:type="xsd:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">https://api.salesforce.com/einstein/ai-agent/v1/agents/{0}/sessions</value>
+        <value
+      xsi:type="xsd:string"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    >https://api.salesforce.com/einstein/ai-agent/v1/agents/{0}/sessions</value>
     </values>
     <values>
         <field>Messages_Endpoint_Url__c</field>
-        <value xsi:type="xsd:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">https://api.salesforce.com/einstein/ai-agent/v1/sessions/{0}/messages</value>
+        <value
+      xsi:type="xsd:string"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    >https://api.salesforce.com/einstein/ai-agent/v1/sessions/{0}/messages</value>
+    </values>
+    <values>
+        <field>Start_Session_Parameters__c</field>
+        <value
+      xsi:type="xsd:string"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    >{"context":{"origin":"AgentforceBuilder"},"sessionConfig":{"mode":"Debug"}}</value>
+    </values>
+    <values>
+        <field>Send_Message_Parameters__c</field>
+        <value
+      xsi:type="xsd:string"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    >{"metadata":{"origin":"AgentforceBuilder"}}</value>
     </values>
     <values>
         <field>Chat_Endpoint_Url__c</field>
-        <value xsi:type="xsd:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">https://example.com/agentforce</value>
+        <value
+      xsi:type="xsd:string"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    >https://example.com/agentforce</value>
     </values>
     <values>
         <field>Named_Credential__c</field>
-        <value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+        <value
+      xsi:nil="true"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    />
     </values>
     <values>
         <field>Authorization_Header_Value__c</field>
-        <value xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+        <value
+      xsi:nil="true"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    />
     </values>
     <values>
         <field>Consumer_Key__c</field>
-        <value xsi:type="xsd:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">sample-client-key</value>
+        <value
+      xsi:type="xsd:string"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    >sample-client-key</value>
     </values>
     <values>
         <field>Consumer_Secret__c</field>
-        <value xsi:type="xsd:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">sample-client-secret</value>
+        <value
+      xsi:type="xsd:string"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    >sample-client-secret</value>
     </values>
     <values>
         <field>Username__c</field>
-        <value xsi:type="xsd:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">agentforce-user@example.com</value>
+        <value
+      xsi:type="xsd:string"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    >agentforce-user@example.com</value>
     </values>
     <values>
         <field>Password__c</field>
-        <value xsi:type="xsd:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">sample-password</value>
+        <value
+      xsi:type="xsd:string"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    >sample-password</value>
     </values>
 </CustomMetadata>

--- a/force-app/main/default/objects/Agentforce_Config__mdt/fields/Send_Message_Parameters__c.field-meta.xml
+++ b/force-app/main/default/objects/Agentforce_Config__mdt/fields/Send_Message_Parameters__c.field-meta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Send_Message_Parameters__c</fullName>
+    <label>Send Message Parameters</label>
+    <length>32768</length>
+    <type>TextArea</type>
+    <visibleLines>5</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/Agentforce_Config__mdt/fields/Start_Session_Parameters__c.field-meta.xml
+++ b/force-app/main/default/objects/Agentforce_Config__mdt/fields/Start_Session_Parameters__c.field-meta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Start_Session_Parameters__c</fullName>
+    <label>Start Session Parameters</label>
+    <length>32768</length>
+    <type>TextArea</type>
+    <visibleLines>5</visibleLines>
+</CustomField>


### PR DESCRIPTION
## Summary
- allow custom metadata to supply additional parameters for Agentforce start session and send message payloads
- apply configured overrides when constructing API requests so builder-style parameters can be forwarded
- add Apex tests covering the override handling logic

## Testing
- npm test *(fails: ReferenceError setImmediate is not defined in Jest environment)*

------
https://chatgpt.com/codex/tasks/task_e_6908a2074da8832cbe33c13e816bd19e