### PR TITLE
Start Agentforce session when launching returns chat

### DIFF
--- a/force-app/main/default/lwc/agentforceChat/agentforceChat.js
+++ b/force-app/main/default/lwc/agentforceChat/agentforceChat.js
@@ -161,6 +161,36 @@ export default class AgentforceChat extends LightningElement {
         }
     }
 
+    @api
+    async applySessionResult(sessionResult) {
+        const normalizedResult = this.normalizeSessionResult(sessionResult);
+        if (!normalizedResult) {
+            return;
+        }
+
+        const sessionId =
+            normalizedResult.sessionId || this.extractSessionId(normalizedResult);
+        const startEndpoint = this.resolvedStartSessionEndpoint;
+        const messagesEndpoint =
+            normalizedResult.messagesUrl ||
+            this.resolveMessagesEndpoint(normalizedResult, sessionId, startEndpoint);
+
+        if (sessionId) {
+            this.sessionId = sessionId;
+        }
+
+        if (messagesEndpoint) {
+            this.messagesEndpoint = messagesEndpoint;
+        }
+
+        if (normalizedResult.externalSessionKey) {
+            this.sessionKey = normalizedResult.externalSessionKey;
+        }
+
+        this.appendInitialMessagesFromStartSession(normalizedResult);
+        this.ensureDefaultNoticeMessage();
+    }
+
     async handleSend() {
         const draft = this.draftMessage;
         this.draftMessage = '';
@@ -226,6 +256,32 @@ export default class AgentforceChat extends LightningElement {
     handleAgentforceError(error) {
         this.errorMessage = this.normalizeError(error);
         this.updateStatusMessage(this.errorMessage, 'error', true);
+    }
+
+    normalizeSessionResult(result) {
+        if (!result || typeof result !== 'object') {
+            return undefined;
+        }
+
+        let normalized;
+        try {
+            normalized = JSON.parse(JSON.stringify(result));
+        } catch (error) {
+            normalized = { ...result };
+        }
+
+        if (result.data && typeof result.data === 'object') {
+            normalized.data = { ...result.data };
+        }
+
+        if (!normalized.data && typeof normalized.body === 'string') {
+            const parsedBody = this.safeParseJson(normalized.body);
+            if (parsedBody && typeof parsedBody === 'object') {
+                normalized.data = parsedBody;
+            }
+        }
+
+        return normalized;
     }
 
     async sendMessageToAgentforce(content) {

--- a/force-app/main/default/lwc/purchaseHistory/__tests__/purchaseHistory.test.js
+++ b/force-app/main/default/lwc/purchaseHistory/__tests__/purchaseHistory.test.js
@@ -8,11 +8,13 @@ jest.mock(
     const initializeConversationMock = jest.fn().mockResolvedValue();
     const prefillDraftMessageMock = jest.fn();
     const focusComposerMock = jest.fn();
+    const applySessionResultMock = jest.fn().mockResolvedValue();
     return {
       __esModule: true,
       initializeConversationMock,
       prefillDraftMessageMock,
       focusComposerMock,
+      applySessionResultMock,
       default: class AgentforceChatStub extends LightningElement {
         initializeConversation(...args) {
           return initializeConversationMock(...args);
@@ -25,6 +27,10 @@ jest.mock(
         focusComposer(...args) {
           return focusComposerMock(...args);
         }
+
+        applySessionResult(...args) {
+          return applySessionResultMock(...args);
+        }
       }
     };
   },
@@ -34,7 +40,8 @@ jest.mock(
 const {
   initializeConversationMock,
   prefillDraftMessageMock,
-  focusComposerMock
+  focusComposerMock,
+  applySessionResultMock
 } = require("c/agentforceChat");
 
 jest.mock(
@@ -44,6 +51,36 @@ jest.mock(
   }),
   { virtual: true }
 );
+
+jest.mock(
+  "@salesforce/apex/AgentforceChatController.startSession",
+  () => ({
+    default: jest.fn().mockResolvedValue({
+      sessionId: "mock-session-id",
+      messagesUrl: "https://example.com/messages",
+      externalSessionKey: "mock-session-key",
+      data: {
+        messages: [
+          {
+            type: "Inform",
+            message: "Hello. This is NovaRigel Returns Agent.",
+            id: "message-1"
+          }
+        ]
+      }
+    })
+  }),
+  { virtual: true }
+);
+
+const startSessionMock = require("@salesforce/apex/AgentforceChatController.startSession").default;
+
+async function flushPromises(iterations = 1) {
+  for (let index = 0; index < iterations; index += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await Promise.resolve();
+  }
+}
 
 describe("c-purchase-history", () => {
   afterEach(() => {
@@ -87,10 +124,11 @@ describe("c-purchase-history", () => {
 
     button.click();
 
+    await flushPromises(2);
     jest.runAllTimers();
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushPromises(2);
+    jest.runAllTimers();
+    await flushPromises(2);
 
     const container = element.shadowRoot.querySelector(
       ".agentforce-chat-container"
@@ -101,6 +139,23 @@ describe("c-purchase-history", () => {
 
     const chatComponent = element.shadowRoot.querySelector("c-agentforce-chat");
     expect(chatComponent).not.toBeNull();
+
+    expect(startSessionMock).toHaveBeenCalledTimes(1);
+    expect(startSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          context: expect.objectContaining({ orderNumber: "00012345" })
+        })
+      })
+    );
+
+    expect(applySessionResultMock).toHaveBeenCalledTimes(1);
+    expect(applySessionResultMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "mock-session-id",
+        messagesUrl: "https://example.com/messages"
+      })
+    );
 
     expect(initializeConversationMock).toHaveBeenCalledTimes(1);
     expect(prefillDraftMessageMock).toHaveBeenCalledWith("00012345");
@@ -143,8 +198,7 @@ describe("c-purchase-history", () => {
 
     button.click();
 
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushPromises(2);
 
     const container = element.shadowRoot.querySelector(
       ".agentforce-chat-container"
@@ -155,5 +209,8 @@ describe("c-purchase-history", () => {
 
     const chatComponent = element.shadowRoot.querySelector("c-agentforce-chat");
     expect(chatComponent).toBeNull();
+
+    expect(startSessionMock).not.toHaveBeenCalled();
+    expect(applySessionResultMock).not.toHaveBeenCalled();
   });
 });

--- a/force-app/main/default/lwc/purchaseHistory/purchaseHistory.js
+++ b/force-app/main/default/lwc/purchaseHistory/purchaseHistory.js
@@ -1,5 +1,6 @@
 import { LightningElement, api } from "lwc";
 import getPurchaseHistory from "@salesforce/apex/PurchaseHistoryController.getPurchaseHistory";
+import startAgentforceSession from "@salesforce/apex/AgentforceChatController.startSession";
 import { ShowToastEvent } from "lightning/platformShowToastEvent";
 
 export default class PurchaseHistory extends LightningElement {
@@ -10,6 +11,7 @@ export default class PurchaseHistory extends LightningElement {
   isAgentforceChatVisible = false;
   isAgentforceChatStarting = false;
   isAgentforceChatSessionReady = false;
+  agentforceSessionResult;
 
   @api
   set testOrders(value) {
@@ -91,22 +93,42 @@ export default class PurchaseHistory extends LightningElement {
       return;
     }
 
-    await this.startAgentforceChat(orderNumber);
+    try {
+      await this.startAgentforceChat(orderNumber);
 
-    this.dispatchEvent(
-      new ShowToastEvent({
-        title: "返品・交換サポート",
-        message: `注文番号: ${orderNumber}のサポートチャットを開始しました。`,
-        variant: "success"
-      })
-    );
+      this.dispatchEvent(
+        new ShowToastEvent({
+          title: "返品・交換サポート",
+          message: `注文番号: ${orderNumber}のサポートチャットを開始しました。`,
+          variant: "success"
+        })
+      );
+    } catch (error) {
+      const message = this.extractErrorMessage(
+        error,
+        "サポートチャットの開始に失敗しました。時間をおいて再度お試しください。"
+      );
+
+      this.dispatchEvent(
+        new ShowToastEvent({
+          title: "返品・交換サポート",
+          message,
+          variant: "error"
+        })
+      );
+    }
   }
 
   async startAgentforceChat(orderNumber) {
     this.isAgentforceChatVisible = true;
     this.isAgentforceChatStarting = true;
+    this.isAgentforceChatSessionReady = false;
+    this.agentforceSessionResult = undefined;
 
     try {
+      const sessionResult = await this.requestAgentforceSession(orderNumber);
+      this.agentforceSessionResult = sessionResult;
+
       if (!this.isAgentforceChatSessionReady) {
         await this.delay(this.chatLaunchDelay);
         this.isAgentforceChatSessionReady = true;
@@ -114,10 +136,135 @@ export default class PurchaseHistory extends LightningElement {
 
       await this.waitForRender();
       await this.prepareAgentforceChat(orderNumber);
+    } catch (error) {
+      this.isAgentforceChatVisible = false;
+      this.agentforceSessionResult = undefined;
+      throw error;
     } finally {
       this.isAgentforceChatStarting = false;
       await this.waitForRender();
     }
+  }
+
+  async requestAgentforceSession(orderNumber) {
+    const payload = this.buildAgentforceSessionPayload(orderNumber);
+    const result = await startAgentforceSession({ payload });
+    return this.normalizeAgentforceSessionResult(result);
+  }
+
+  buildAgentforceSessionPayload(orderNumber) {
+    const payload = {};
+    const normalizedOrderNumber = this.normalizeOrderNumber(orderNumber);
+
+    if (normalizedOrderNumber) {
+      payload.context = {
+        orderNumber: normalizedOrderNumber
+      };
+    }
+
+    return payload;
+  }
+
+  normalizeAgentforceSessionResult(result) {
+    if (!result) {
+      return undefined;
+    }
+
+    const normalized = this.cloneSerializable(result);
+
+    if (normalized && normalized.data && typeof normalized.data !== "object") {
+      normalized.data = this.parseJsonSafely(normalized.data);
+    }
+
+    if (!normalized?.data && typeof normalized?.body === "string") {
+      const parsed = this.parseJsonSafely(normalized.body);
+      if (parsed && typeof parsed === "object") {
+        normalized.data = parsed;
+      }
+    }
+
+    return normalized;
+  }
+
+  cloneSerializable(value) {
+    if (value === null || value === undefined) {
+      return value;
+    }
+
+    if (typeof structuredClone === "function") {
+      try {
+        return structuredClone(value);
+      } catch (error) {
+        // Ignore structured clone errors and fall back to other strategies.
+      }
+    }
+
+    if (
+      typeof window !== "undefined" &&
+      typeof window.structuredClone === "function"
+    ) {
+      try {
+        return window.structuredClone(value);
+      } catch (error) {
+        // Ignore structured clone errors and fall back to JSON parsing.
+      }
+    }
+
+    try {
+      return JSON.parse(JSON.stringify(value));
+    } catch (error) {
+      return value;
+    }
+  }
+
+  parseJsonSafely(value) {
+    if (!value || typeof value !== "string") {
+      return undefined;
+    }
+
+    try {
+      return JSON.parse(value);
+    } catch (error) {
+      return undefined;
+    }
+  }
+
+  extractErrorMessage(error, fallbackMessage) {
+    if (!error) {
+      return fallbackMessage;
+    }
+
+    if (typeof error === "string" && error.trim()) {
+      return error.trim();
+    }
+
+    if (error.body) {
+      if (typeof error.body === "string" && error.body.trim()) {
+        return error.body.trim();
+      }
+
+      if (
+        typeof error.body.message === "string" &&
+        error.body.message.trim()
+      ) {
+        return error.body.message.trim();
+      }
+    }
+
+    if (typeof error.message === "string" && error.message.trim()) {
+      return error.message.trim();
+    }
+
+    return fallbackMessage;
+  }
+
+  normalizeOrderNumber(orderNumber) {
+    if (orderNumber === null || orderNumber === undefined) {
+      return "";
+    }
+
+    const value = String(orderNumber).trim();
+    return value;
   }
 
   get chatLaunchDelay() {
@@ -150,6 +297,13 @@ export default class PurchaseHistory extends LightningElement {
     }
 
     try {
+      if (
+        this.agentforceSessionResult &&
+        typeof chat.applySessionResult === "function"
+      ) {
+        await chat.applySessionResult(this.agentforceSessionResult);
+      }
+
       if (typeof chat.initializeConversation === "function") {
         await chat.initializeConversation();
       }
@@ -157,10 +311,7 @@ export default class PurchaseHistory extends LightningElement {
       console.error("Failed to initialize Agentforce chat session", error);
     }
 
-    const normalizedOrderNumber =
-      orderNumber === null || orderNumber === undefined
-        ? ""
-        : String(orderNumber);
+    const normalizedOrderNumber = this.normalizeOrderNumber(orderNumber);
 
     try {
       if (typeof chat.prefillDraftMessage === "function") {
@@ -181,6 +332,7 @@ export default class PurchaseHistory extends LightningElement {
     this.isAgentforceChatVisible = false;
     this.isAgentforceChatStarting = false;
     this.isAgentforceChatSessionReady = false;
+    this.agentforceSessionResult = undefined;
   }
 
   groupHistoryByOrder(historyItems) {


### PR DESCRIPTION
## Summary
- start the Agentforce session from the purchase history action before rendering the chat and surface toast feedback on failure
- hand the retrieved session to the chat component so the initial Agentforce message is displayed immediately
- extend the unit test to cover the new session start call and chat preparation flow

## Testing
- npm test *(fails: sfdx-lwc-jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6908ae1e5670832c948f6cc8a868a6ea