### PR TITLE
Refine Agentforce start session payload structure

### DIFF
--- a/force-app/main/default/classes/AgentforceChatController.cls
+++ b/force-app/main/default/classes/AgentforceChatController.cls
@@ -270,7 +270,10 @@ public with sharing class AgentforceChatController {
     Map<String, Object> payloadToSend = payload != null
       ? new Map<String, Object>(payload)
       : new Map<String, Object>();
-    applyDefaultStartSessionPayload(payloadToSend);
+    applyDefaultStartSessionPayload(
+      payloadToSend,
+      config != null ? config.Endpoint_Url__c : null
+    );
 
     applyConfiguredPayloadOverrides(
       payloadToSend,
@@ -427,7 +430,8 @@ public with sharing class AgentforceChatController {
   }
 
   private static void applyDefaultStartSessionPayload(
-    Map<String, Object> payload
+    Map<String, Object> payload,
+    String defaultInstanceEndpoint
   ) {
     if (payload == null) {
       return;
@@ -441,46 +445,97 @@ public with sharing class AgentforceChatController {
       payload.put('externalSessionKey', generateExternalSessionKey());
     }
 
-    Map<String, Object> instanceConfig = new Map<String, Object>();
+    Map<String, Object> sessionConfig = new Map<String, Object>();
     if (
-      payload.containsKey('instanceConfig') &&
-      payload.get('instanceConfig') instanceof Map<String, Object>
+      payload.containsKey('sessionConfig') &&
+      payload.get('sessionConfig') instanceof Map<String, Object>
     ) {
-      instanceConfig.putAll(
-        (Map<String, Object>) payload.get('instanceConfig')
+      sessionConfig.putAll(
+        (Map<String, Object>) payload.get('sessionConfig')
+      );
+    }
+
+    Map<String, Object> forceConfig = new Map<String, Object>();
+    if (
+      sessionConfig.containsKey('forceConfig') &&
+      sessionConfig.get('forceConfig') instanceof Map<String, Object>
+    ) {
+      forceConfig.putAll(
+        (Map<String, Object>) sessionConfig.get('forceConfig')
+      );
+    } else if (
+      sessionConfig.containsKey('instanceConfig') &&
+      sessionConfig.get('instanceConfig') instanceof Map<String, Object>
+    ) {
+      forceConfig.putAll(
+        (Map<String, Object>) sessionConfig.get('instanceConfig')
       );
     }
     if (
-      !instanceConfig.containsKey('endpoint') ||
-      !(instanceConfig.get('endpoint') instanceof String) ||
-      String.isBlank((String) instanceConfig.get('endpoint'))
+      forceConfig.isEmpty() &&
+      payload.containsKey('forceConfig') &&
+      payload.get('forceConfig') instanceof Map<String, Object>
     ) {
+      forceConfig.putAll((Map<String, Object>) payload.get('forceConfig'));
+    }
+    if (
+      forceConfig.isEmpty() &&
+      payload.containsKey('instanceConfig') &&
+      payload.get('instanceConfig') instanceof Map<String, Object>
+    ) {
+      forceConfig.putAll(
+        (Map<String, Object>) payload.get('instanceConfig')
+      );
+    }
+
+    String forceEndpoint =
+      forceConfig.containsKey('endpoint') &&
+      forceConfig.get('endpoint') instanceof String
+        ? (String) forceConfig.get('endpoint')
+        : null;
+    if (String.isBlank(forceEndpoint)) {
+      forceEndpoint = defaultInstanceEndpoint;
+    }
+    if (String.isBlank(forceEndpoint)) {
       try {
-        instanceConfig.put(
-          'endpoint',
-          'https://orgfarm-ba397eacea-dev-ed.develop.my.salesforce.com'
-        );
+        forceEndpoint = URL.getSalesforceBaseUrl().toExternalForm();
       } catch (Exception ex) {
         // If the base URL cannot be resolved we leave the endpoint unset.
       }
     }
-    payload.put('instanceConfig', instanceConfig);
+    if (String.isNotBlank(forceEndpoint)) {
+      forceConfig.put('endpoint', forceEndpoint);
+    }
+    sessionConfig.put('forceConfig', forceConfig);
+    sessionConfig.remove('instanceConfig');
 
-    Object tzValue = payload.get('tz');
-    if (!(tzValue instanceof String) || String.isBlank((String) tzValue)) {
+    Object tzValue = sessionConfig.containsKey('tz')
+      ? sessionConfig.get('tz')
+      : payload.get('tz');
+    String tzString = tzValue instanceof String ? (String) tzValue : null;
+    if (String.isBlank(tzString)) {
       try {
-        payload.put('tz', UserInfo.getTimeZone().getID());
+        sessionConfig.put('tz', UserInfo.getTimeZone().getID());
       } catch (Exception ex) {
         // Ignore and leave timezone unset when unavailable.
       }
+    } else {
+      sessionConfig.put('tz', tzString);
     }
 
-    Boolean hasVariables =
+    List<Object> variables = sessionConfig.containsKey('variables') &&
+      sessionConfig.get('variables') instanceof List<Object>
+      ? new List<Object>((List<Object>) sessionConfig.get('variables'))
+      : null;
+    if (
+      (variables == null || variables.isEmpty()) &&
       payload.containsKey('variables') &&
-      payload.get('variables') instanceof List<Object> &&
-      !((List<Object>) payload.get('variables')).isEmpty();
-    if (!hasVariables) {
-      List<Object> variables = new List<Object>();
+      payload.get('variables') instanceof List<Object>
+    ) {
+      variables = new List<Object>((List<Object>) payload.get('variables'));
+    }
+    if (variables == null || variables.isEmpty()) {
+      variables = new List<Object>();
       variables.add(
         new Map<String, Object>{
           'name' => '$Context.EndUserLanguage',
@@ -502,19 +557,29 @@ public with sharing class AgentforceChatController {
           'value' => UserInfo.getUserType()
         }
       );
-      payload.put('variables', variables);
     }
+    sessionConfig.put('variables', variables);
 
-    Object featureSupport = payload.get('featureSupport');
-    if (
-      !(featureSupport instanceof String) ||
-      String.isBlank((String) featureSupport)
-    ) {
-      payload.put('featureSupport', 'Streaming');
+    Object featureSupport = sessionConfig.containsKey('featureSupport')
+      ? sessionConfig.get('featureSupport')
+      : payload.get('featureSupport');
+    String featureSupportString = featureSupport instanceof String
+      ? (String) featureSupport
+      : null;
+    if (String.isBlank(featureSupportString)) {
+      featureSupportString = 'Streaming';
     }
+    sessionConfig.put('featureSupport', featureSupportString);
 
     Map<String, Object> streamingCapabilities = new Map<String, Object>();
     if (
+      sessionConfig.containsKey('streamingCapabilities') &&
+      sessionConfig.get('streamingCapabilities') instanceof Map<String, Object>
+    ) {
+      streamingCapabilities.putAll(
+        (Map<String, Object>) sessionConfig.get('streamingCapabilities')
+      );
+    } else if (
       payload.containsKey('streamingCapabilities') &&
       payload.get('streamingCapabilities') instanceof Map<String, Object>
     ) {
@@ -529,7 +594,15 @@ public with sharing class AgentforceChatController {
     if (!hasChunkTypes) {
       streamingCapabilities.put('chunkTypes', new List<Object>{ 'Text' });
     }
-    payload.put('streamingCapabilities', streamingCapabilities);
+    sessionConfig.put('streamingCapabilities', streamingCapabilities);
+
+    payload.put('sessionConfig', sessionConfig);
+    payload.remove('instanceConfig');
+    payload.remove('forceConfig');
+    payload.remove('tz');
+    payload.remove('variables');
+    payload.remove('featureSupport');
+    payload.remove('streamingCapabilities');
   }
 
   private static void applyConfiguredPayloadOverrides(

--- a/force-app/main/default/lwc/agentforceChat/__tests__/agentforceChat.test.js
+++ b/force-app/main/default/lwc/agentforceChat/__tests__/agentforceChat.test.js
@@ -56,7 +56,14 @@ jest.mock(
 
 const getConfigAdapter = registerApexTestWireAdapter(mockGetConfig);
 
-const flushPromises = () => new Promise(setImmediate);
+const flushPromises = () =>
+    Promise.resolve().then(
+        () =>
+            new Promise((resolve) => {
+                // eslint-disable-next-line @lwc/lwc/no-async-operation
+                setTimeout(resolve, 0);
+            })
+    );
 
 const DEFAULT_START_SESSION_NOTICE = `こんにちは。NovaRigel返品エージェントです。
 ご購入商品の返品や交換に関するご相談をサポートいたします。
@@ -83,6 +90,8 @@ describe('c-agentforce-chat', () => {
             messagesEndpointUrl: 'https://default.example.com',
             botId: 'default-bot'
         });
+
+        await flushPromises();
 
         mockStartSession.mockResolvedValue({
             sessionId: 'session-123',
@@ -111,6 +120,21 @@ describe('c-agentforce-chat', () => {
         expect(mockStartSession).toHaveBeenCalledWith(
             expect.objectContaining({
                 endpointUrl: 'https://example.com/api'
+            })
+        );
+
+        const startSessionCall = mockStartSession.mock.calls[0][0];
+        expect(startSessionCall.payload).toEqual(
+            expect.objectContaining({
+                sessionConfig: expect.objectContaining({
+                    forceConfig: expect.objectContaining({
+                        endpoint: expect.any(String)
+                    }),
+                    featureSupport: 'Streaming',
+                    streamingCapabilities: expect.objectContaining({
+                        chunkTypes: ['Text']
+                    })
+                })
             })
         );
 
@@ -147,6 +171,8 @@ describe('c-agentforce-chat', () => {
             messagesEndpointUrl: 'https://default.example.com',
             botId: 'default-bot'
         });
+
+        await flushPromises();
 
         mockStartSession.mockResolvedValue({
             sessionId: 'session-123',
@@ -192,6 +218,8 @@ describe('c-agentforce-chat', () => {
             messagesEndpointUrl: 'https://example.com/messages',
             botId: 'bot-notice'
         });
+
+        await flushPromises();
 
         mockStartSession.mockResolvedValueOnce({
             sessionId: 'session-notice',
@@ -253,47 +281,6 @@ describe('c-agentforce-chat', () => {
         expect(agentMessages[0]).toBe(DEFAULT_START_SESSION_NOTICE);
     });
 
-    it('initializes the session and renders notice messages from the start session response', async () => {
-        const element = createElement('c-agentforce-chat', {
-            is: AgentforceChat
-        });
-        element.botId = 'bot-notice';
-        document.body.appendChild(element);
-
-        getConfigAdapter.emit({
-            startSessionEndpointUrl: 'https://example.com/sessions',
-            messagesEndpointUrl: 'https://example.com/messages',
-            botId: 'bot-notice'
-        });
-
-        mockStartSession.mockResolvedValueOnce({
-            sessionId: 'session-notice',
-            messagesUrl: 'https://example.com/messages/session-notice',
-            data: {
-                session: {
-                    noticeMessages: [
-                        '返品・交換サポートへようこそ。',
-                        { message: '注文番号を入力してください。', type: 'notice' }
-                    ]
-                }
-            }
-        });
-
-        await flushPromises();
-
-        await element.initializeConversation();
-        await flushPromises();
-
-        expect(mockStartSession).toHaveBeenCalledTimes(1);
-
-        const agentMessages = Array.from(
-            element.shadowRoot.querySelectorAll('div[data-role="agent"] .message-body')
-        ).map((node) => node.textContent);
-
-        expect(agentMessages).toContain('返品・交換サポートへようこそ。');
-        expect(agentMessages).toContain('注文番号を入力してください。');
-    });
-
     it('builds the messages endpoint from configured metadata when the session response omits URLs', async () => {
         const element = createElement('c-agentforce-chat', {
             is: AgentforceChat
@@ -308,6 +295,8 @@ describe('c-agentforce-chat', () => {
                 'https://api.salesforce.com/einstein/ai-agent/v1/sessions/{0}/messages',
             botId: 'bot-123'
         });
+
+        await flushPromises();
 
         mockStartSession.mockResolvedValue({
             sessionId: 'session-789'
@@ -364,6 +353,8 @@ describe('c-agentforce-chat', () => {
             botId: 'ignored-bot'
         });
 
+        await flushPromises();
+
         mockStartSession.mockResolvedValue({
             sessionId: 'session-456'
         });
@@ -413,6 +404,8 @@ describe('c-agentforce-chat', () => {
             botId: 'default-bot'
         });
 
+        await flushPromises();
+
         mockStartSession.mockResolvedValue({
             sessionId: 'session-999',
             messagesUrl: 'https://example.com/api/sessions/session-999/messages'
@@ -446,20 +439,6 @@ describe('c-agentforce-chat', () => {
 
         expect(agentMessages[0]).toBe(DEFAULT_START_SESSION_NOTICE);
         expect(agentMessages[agentMessages.length - 1]).toBe('Acknowledged');
-    });
-
-    it('prefills the composer when prefillDraftMessage is invoked', async () => {
-        const element = createElement('c-agentforce-chat', {
-            is: AgentforceChat
-        });
-        document.body.appendChild(element);
-
-        element.prefillDraftMessage('00099999');
-
-        await flushPromises();
-
-        const textarea = element.shadowRoot.querySelector('lightning-textarea');
-        expect(textarea.value).toBe('00099999');
     });
 
     it('prefills the composer when prefillDraftMessage is invoked', async () => {

--- a/force-app/main/default/lwc/agentforceChat/agentforceChat.js
+++ b/force-app/main/default/lwc/agentforceChat/agentforceChat.js
@@ -31,6 +31,7 @@ export default class AgentforceChat extends LightningElement {
 
     set startSessionEndpointUrl(value) {
         this._startSessionEndpointUrl = value;
+        this.resolveConfigReady();
     }
 
     @api
@@ -39,7 +40,8 @@ export default class AgentforceChat extends LightningElement {
     }
 
     set endpointUrl(value) {
-        this.startSessionEndpointUrl = value;
+        this._startSessionEndpointUrl = value;
+        this.resolveConfigReady();
     }
 
     @api
@@ -72,6 +74,8 @@ export default class AgentforceChat extends LightningElement {
     sessionInitializationPromise;
 
     wiredConfig;
+    _configReadyPromise;
+    _configReadyResolver;
 
     @wire(getConfig)
     wiredGetConfig(value) {
@@ -81,9 +85,9 @@ export default class AgentforceChat extends LightningElement {
             this.applyConfig(data);
         } else if (error) {
             this.errorMessage = 'Configuration error';
-            // eslint-disable-next-line no-console
             console.error('AgentforceChat configuration error', error);
         }
+        this.resolveConfigReady();
     }
 
     renderedCallback() {
@@ -266,7 +270,7 @@ export default class AgentforceChat extends LightningElement {
         let normalized;
         try {
             normalized = JSON.parse(JSON.stringify(result));
-        } catch (error) {
+        } catch {
             normalized = { ...result };
         }
 
@@ -316,8 +320,11 @@ export default class AgentforceChat extends LightningElement {
         }
 
         if (this.sessionInitializationPromise) {
-            return this.sessionInitializationPromise;
+            await this.sessionInitializationPromise;
+            return;
         }
+
+        await this.waitForConfig();
 
         const botId = this.resolvedBotId;
         if (!botId) {
@@ -356,6 +363,31 @@ export default class AgentforceChat extends LightningElement {
         this.ensureDefaultNoticeMessage();
     }
 
+    waitForConfig() {
+        if (
+            this.resolvedStartSessionEndpoint ||
+            (this.wiredConfig && (this.wiredConfig.data || this.wiredConfig.error))
+        ) {
+            return Promise.resolve();
+        }
+
+        if (!this._configReadyPromise) {
+            this._configReadyPromise = new Promise((resolve) => {
+                this._configReadyResolver = resolve;
+            });
+        }
+
+        return this._configReadyPromise;
+    }
+
+    resolveConfigReady() {
+        if (this._configReadyResolver) {
+            this._configReadyResolver();
+            this._configReadyResolver = undefined;
+            this._configReadyPromise = undefined;
+        }
+    }
+
     buildStartSessionEndpoint(template, botId) {
         if (!template) {
             return template;
@@ -380,35 +412,47 @@ export default class AgentforceChat extends LightningElement {
 
     buildStartSessionPayload() {
         const sessionKey = this.sessionKey || this.generateExternalSessionKey();
-        const payload = {
-            externalSessionKey: sessionKey,
-            instanceConfig: {
-                endpoint: this.resolvedInstanceEndpoint
+        const sessionConfig = {};
+
+        const instanceEndpoint = this.resolvedInstanceEndpoint;
+        if (instanceEndpoint) {
+            sessionConfig.forceConfig = {
+                endpoint: instanceEndpoint
+            };
+        }
+
+        const timezone = USER_TIMEZONE || this.getBrowserTimeZone();
+        if (timezone) {
+            sessionConfig.tz = timezone;
+        }
+
+        sessionConfig.variables = [
+            {
+                name: '$Context.EndUserLanguage',
+                type: 'Text',
+                value: this.normalizeLocale(USER_LOCALE)
             },
-            tz: USER_TIMEZONE || this.getBrowserTimeZone(),
-            variables: [
-                {
-                    name: '$Context.EndUserLanguage',
-                    type: 'Text',
-                    value: this.normalizeLocale(USER_LOCALE)
-                },
-                {
-                    name: '$Context.EndUser.Id',
-                    type: 'Text',
-                    value: USER_ID
-                },
-                {
-                    name: '$Context.EndUser.Type',
-                    type: 'Text',
-                    value: 'SalesforceUser'
-                }
-            ],
-            featureSupport: 'Streaming',
-            streamingCapabilities: {
-                chunkTypes: ['Text']
+            {
+                name: '$Context.EndUser.Id',
+                type: 'Text',
+                value: USER_ID
+            },
+            {
+                name: '$Context.EndUser.Type',
+                type: 'Text',
+                value: 'SalesforceUser'
             }
+        ];
+
+        sessionConfig.featureSupport = 'Streaming';
+        sessionConfig.streamingCapabilities = {
+            chunkTypes: ['Text']
         };
-        return payload;
+
+        return {
+            externalSessionKey: sessionKey,
+            sessionConfig
+        };
     }
 
     extractSessionId(result) {
@@ -520,7 +564,7 @@ export default class AgentforceChat extends LightningElement {
     getBrowserTimeZone() {
         try {
             return Intl.DateTimeFormat().resolvedOptions().timeZone;
-        } catch (error) {
+        } catch {
             return 'UTC';
         }
     }
@@ -667,7 +711,7 @@ export default class AgentforceChat extends LightningElement {
 
         try {
             return JSON.parse(value);
-        } catch (error) {
+        } catch {
             return undefined;
         }
     }
@@ -796,9 +840,9 @@ export default class AgentforceChat extends LightningElement {
         const statusId = this.statusMessageId;
         const replacement = this.createMessage('agent', content, variant);
 
-        this.messages = this.messages.map((message) =>
-            message.id === statusId ? { ...replacement, id: statusId } : message
-        );
+        this.messages = this.messages.map((message) => {
+            return message.id === statusId ? { ...replacement, id: statusId } : message;
+        });
 
         if (finalize) {
             this.statusMessageId = undefined;
@@ -812,9 +856,9 @@ export default class AgentforceChat extends LightningElement {
         }
 
         const statusId = this.statusMessageId;
-        this.messages = this.messages.map((existing) =>
-            existing.id === statusId ? { ...message, id: statusId } : existing
-        );
+        this.messages = this.messages.map((existing) => {
+            return existing.id === statusId ? { ...message, id: statusId } : existing;
+        });
         this.statusMessageId = undefined;
     }
 

--- a/force-app/main/default/lwc/purchaseHistory/__tests__/purchaseHistory.test.js
+++ b/force-app/main/default/lwc/purchaseHistory/__tests__/purchaseHistory.test.js
@@ -16,20 +16,15 @@ jest.mock(
       focusComposerMock,
       applySessionResultMock,
       default: class AgentforceChatStub extends LightningElement {
-        initializeConversation(...args) {
-          return initializeConversationMock(...args);
-        }
-
-        prefillDraftMessage(...args) {
-          return prefillDraftMessageMock(...args);
-        }
-
-        focusComposer(...args) {
-          return focusComposerMock(...args);
-        }
-
-        applySessionResult(...args) {
-          return applySessionResultMock(...args);
+        constructor() {
+          super();
+          this.initializeConversation = (...args) =>
+            initializeConversationMock(...args);
+          this.prefillDraftMessage = (...args) =>
+            prefillDraftMessageMock(...args);
+          this.focusComposer = (...args) => focusComposerMock(...args);
+          this.applySessionResult = (...args) =>
+            applySessionResultMock(...args);
         }
       }
     };


### PR DESCRIPTION
## Summary
- move default start session fields into the `sessionConfig` object and strip obsolete top-level keys before sending the request
- update the Agentforce chat LWC to build the new payload shape, wait for configuration data, and expose setters without reassigning public API values
- adjust Jest tests for the chat component and purchase history flow to expect the new structure and ensure mocks expose the same public methods
- ensure the start-session payload surfaces the Force config endpoint under `sessionConfig.forceConfig`, migrate legacy `instanceConfig` overrides, and align the LWC/tests with the updated shape

## Testing
- `npm test` *(fails: `sfdx-lwc-jest` is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_690968535cfc832ca0b4192437609cda