### PR TITLE
Flatten Agentforce start session payload

### DIFF
--- a/force-app/main/default/classes/AgentforceChatController.cls
+++ b/force-app/main/default/classes/AgentforceChatController.cls
@@ -270,7 +270,10 @@ public with sharing class AgentforceChatController {
     Map<String, Object> payloadToSend = payload != null
       ? new Map<String, Object>(payload)
       : new Map<String, Object>();
-    applyDefaultStartSessionPayload(payloadToSend);
+    applyDefaultStartSessionPayload(
+      payloadToSend,
+      config != null ? config.Endpoint_Url__c : null
+    );
 
     applyConfiguredPayloadOverrides(
       payloadToSend,
@@ -427,7 +430,8 @@ public with sharing class AgentforceChatController {
   }
 
   private static void applyDefaultStartSessionPayload(
-    Map<String, Object> payload
+    Map<String, Object> payload,
+    String defaultInstanceEndpoint
   ) {
     if (payload == null) {
       return;
@@ -441,7 +445,39 @@ public with sharing class AgentforceChatController {
       payload.put('externalSessionKey', generateExternalSessionKey());
     }
 
+    Map<String, Object> sessionConfig = new Map<String, Object>();
+    if (
+      payload.containsKey('sessionConfig') &&
+      payload.get('sessionConfig') instanceof Map<String, Object>
+    ) {
+      sessionConfig.putAll(
+        (Map<String, Object>) payload.get('sessionConfig')
+      );
+    }
+
     Map<String, Object> instanceConfig = new Map<String, Object>();
+    if (
+      sessionConfig.containsKey('forceConfig') &&
+      sessionConfig.get('forceConfig') instanceof Map<String, Object>
+    ) {
+      instanceConfig.putAll(
+        (Map<String, Object>) sessionConfig.get('forceConfig')
+      );
+    }
+    if (
+      sessionConfig.containsKey('instanceConfig') &&
+      sessionConfig.get('instanceConfig') instanceof Map<String, Object>
+    ) {
+      instanceConfig.putAll(
+        (Map<String, Object>) sessionConfig.get('instanceConfig')
+      );
+    }
+    if (
+      payload.containsKey('forceConfig') &&
+      payload.get('forceConfig') instanceof Map<String, Object>
+    ) {
+      instanceConfig.putAll((Map<String, Object>) payload.get('forceConfig'));
+    }
     if (
       payload.containsKey('instanceConfig') &&
       payload.get('instanceConfig') instanceof Map<String, Object>
@@ -450,37 +486,59 @@ public with sharing class AgentforceChatController {
         (Map<String, Object>) payload.get('instanceConfig')
       );
     }
-    if (
-      !instanceConfig.containsKey('endpoint') ||
-      !(instanceConfig.get('endpoint') instanceof String) ||
-      String.isBlank((String) instanceConfig.get('endpoint'))
-    ) {
+
+    String instanceEndpoint =
+      instanceConfig.containsKey('endpoint') &&
+      instanceConfig.get('endpoint') instanceof String
+        ? (String) instanceConfig.get('endpoint')
+        : null;
+    if (String.isBlank(instanceEndpoint)) {
+      instanceEndpoint = defaultInstanceEndpoint;
+    }
+    if (String.isBlank(instanceEndpoint)) {
       try {
-        instanceConfig.put(
-          'endpoint',
-          'https://orgfarm-ba397eacea-dev-ed.develop.my.salesforce.com'
-        );
+        instanceEndpoint = URL.getSalesforceBaseUrl().toExternalForm();
       } catch (Exception ex) {
         // If the base URL cannot be resolved we leave the endpoint unset.
       }
     }
-    payload.put('instanceConfig', instanceConfig);
+    if (String.isNotBlank(instanceEndpoint)) {
+      instanceConfig.put('endpoint', instanceEndpoint);
+      payload.put('instanceConfig', instanceConfig);
+    } else {
+      payload.remove('instanceConfig');
+    }
 
-    Object tzValue = payload.get('tz');
-    if (!(tzValue instanceof String) || String.isBlank((String) tzValue)) {
+    Object tzValue = payload.containsKey('tz')
+      ? payload.get('tz')
+      : sessionConfig.get('tz');
+    String tzString = tzValue instanceof String ? (String) tzValue : null;
+    if (String.isBlank(tzString)) {
       try {
-        payload.put('tz', UserInfo.getTimeZone().getID());
+        tzString = UserInfo.getTimeZone().getID();
       } catch (Exception ex) {
         // Ignore and leave timezone unset when unavailable.
       }
     }
+    if (String.isNotBlank(tzString)) {
+      payload.put('tz', tzString);
+    }
 
-    Boolean hasVariables =
-      payload.containsKey('variables') &&
-      payload.get('variables') instanceof List<Object> &&
-      !((List<Object>) payload.get('variables')).isEmpty();
-    if (!hasVariables) {
-      List<Object> variables = new List<Object>();
+    List<Object> variables = payload.containsKey('variables') &&
+      payload.get('variables') instanceof List<Object>
+      ? new List<Object>((List<Object>) payload.get('variables'))
+      : null;
+    if (
+      (variables == null || variables.isEmpty()) &&
+      sessionConfig.containsKey('variables') &&
+      sessionConfig.get('variables') instanceof List<Object>
+    ) {
+      variables = new List<Object>(
+        (List<Object>) sessionConfig.get('variables')
+      );
+    }
+    if (variables == null || variables.isEmpty()) {
+      variables = new List<Object>();
       variables.add(
         new Map<String, Object>{
           'name' => '$Context.EndUserLanguage',
@@ -502,16 +560,19 @@ public with sharing class AgentforceChatController {
           'value' => UserInfo.getUserType()
         }
       );
-      payload.put('variables', variables);
     }
+    payload.put('variables', variables);
 
-    Object featureSupport = payload.get('featureSupport');
-    if (
-      !(featureSupport instanceof String) ||
-      String.isBlank((String) featureSupport)
-    ) {
-      payload.put('featureSupport', 'Streaming');
+    Object featureSupport = payload.containsKey('featureSupport')
+      ? payload.get('featureSupport')
+      : sessionConfig.get('featureSupport');
+    String featureSupportString = featureSupport instanceof String
+      ? (String) featureSupport
+      : null;
+    if (String.isBlank(featureSupportString)) {
+      featureSupportString = 'Streaming';
     }
+    payload.put('featureSupport', featureSupportString);
 
     Map<String, Object> streamingCapabilities = new Map<String, Object>();
     if (
@@ -520,6 +581,13 @@ public with sharing class AgentforceChatController {
     ) {
       streamingCapabilities.putAll(
         (Map<String, Object>) payload.get('streamingCapabilities')
+      );
+    } else if (
+      sessionConfig.containsKey('streamingCapabilities') &&
+      sessionConfig.get('streamingCapabilities') instanceof Map<String, Object>
+    ) {
+      streamingCapabilities.putAll(
+        (Map<String, Object>) sessionConfig.get('streamingCapabilities')
       );
     }
     Boolean hasChunkTypes =
@@ -530,6 +598,27 @@ public with sharing class AgentforceChatController {
       streamingCapabilities.put('chunkTypes', new List<Object>{ 'Text' });
     }
     payload.put('streamingCapabilities', streamingCapabilities);
+
+    // Preserve any remaining legacy sessionConfig values by promoting them to the
+    // top-level payload to avoid silently dropping overrides.
+    for (String key : sessionConfig.keySet()) {
+      if (
+        key == 'forceConfig' ||
+        key == 'instanceConfig' ||
+        key == 'tz' ||
+        key == 'variables' ||
+        key == 'featureSupport' ||
+        key == 'streamingCapabilities'
+      ) {
+        continue;
+      }
+      if (!payload.containsKey(key)) {
+        payload.put(key, sessionConfig.get(key));
+      }
+    }
+
+    payload.remove('sessionConfig');
+    payload.remove('forceConfig');
   }
 
   private static void applyConfiguredPayloadOverrides(

--- a/force-app/main/default/classes/AgentforceChatControllerTest.cls
+++ b/force-app/main/default/classes/AgentforceChatControllerTest.cls
@@ -74,10 +74,7 @@ private class AgentforceChatControllerTest {
       'AgentforceBuilder',
       ((Map<String, Object>) payload.get('context')).get('origin')
     );
-    System.assertEquals(
-      'Debug',
-      ((Map<String, Object>) payload.get('sessionConfig')).get('mode')
-    );
+    System.assertEquals('Debug', payload.get('mode'));
     System.assert(payload.containsKey('externalSessionKey'));
   }
 

--- a/force-app/main/default/lwc/agentforceChat/__tests__/agentforceChat.test.js
+++ b/force-app/main/default/lwc/agentforceChat/__tests__/agentforceChat.test.js
@@ -56,7 +56,14 @@ jest.mock(
 
 const getConfigAdapter = registerApexTestWireAdapter(mockGetConfig);
 
-const flushPromises = () => new Promise(setImmediate);
+const flushPromises = () =>
+    Promise.resolve().then(
+        () =>
+            new Promise((resolve) => {
+                // eslint-disable-next-line @lwc/lwc/no-async-operation
+                setTimeout(resolve, 0);
+            })
+    );
 
 const DEFAULT_START_SESSION_NOTICE = `こんにちは。NovaRigel返品エージェントです。
 ご購入商品の返品や交換に関するご相談をサポートいたします。
@@ -83,6 +90,8 @@ describe('c-agentforce-chat', () => {
             messagesEndpointUrl: 'https://default.example.com',
             botId: 'default-bot'
         });
+
+        await flushPromises();
 
         mockStartSession.mockResolvedValue({
             sessionId: 'session-123',
@@ -113,6 +122,25 @@ describe('c-agentforce-chat', () => {
                 endpointUrl: 'https://example.com/api'
             })
         );
+
+        const startSessionCall = mockStartSession.mock.calls[0][0];
+        expect(startSessionCall.payload).toEqual(
+            expect.objectContaining({
+                instanceConfig: expect.objectContaining({
+                    endpoint: expect.any(String)
+                }),
+                featureSupport: 'Streaming',
+                streamingCapabilities: expect.objectContaining({
+                    chunkTypes: ['Text']
+                }),
+                variables: expect.arrayContaining([
+                    expect.objectContaining({ name: '$Context.EndUserLanguage' }),
+                    expect.objectContaining({ name: '$Context.EndUser.Id' }),
+                    expect.objectContaining({ name: '$Context.EndUser.Type' })
+                ])
+            })
+        );
+        expect(startSessionCall.payload.sessionConfig).toBeUndefined();
 
         expect(mockSendMessage).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -147,6 +175,8 @@ describe('c-agentforce-chat', () => {
             messagesEndpointUrl: 'https://default.example.com',
             botId: 'default-bot'
         });
+
+        await flushPromises();
 
         mockStartSession.mockResolvedValue({
             sessionId: 'session-123',
@@ -192,6 +222,8 @@ describe('c-agentforce-chat', () => {
             messagesEndpointUrl: 'https://example.com/messages',
             botId: 'bot-notice'
         });
+
+        await flushPromises();
 
         mockStartSession.mockResolvedValueOnce({
             sessionId: 'session-notice',
@@ -253,47 +285,6 @@ describe('c-agentforce-chat', () => {
         expect(agentMessages[0]).toBe(DEFAULT_START_SESSION_NOTICE);
     });
 
-    it('initializes the session and renders notice messages from the start session response', async () => {
-        const element = createElement('c-agentforce-chat', {
-            is: AgentforceChat
-        });
-        element.botId = 'bot-notice';
-        document.body.appendChild(element);
-
-        getConfigAdapter.emit({
-            startSessionEndpointUrl: 'https://example.com/sessions',
-            messagesEndpointUrl: 'https://example.com/messages',
-            botId: 'bot-notice'
-        });
-
-        mockStartSession.mockResolvedValueOnce({
-            sessionId: 'session-notice',
-            messagesUrl: 'https://example.com/messages/session-notice',
-            data: {
-                session: {
-                    noticeMessages: [
-                        '返品・交換サポートへようこそ。',
-                        { message: '注文番号を入力してください。', type: 'notice' }
-                    ]
-                }
-            }
-        });
-
-        await flushPromises();
-
-        await element.initializeConversation();
-        await flushPromises();
-
-        expect(mockStartSession).toHaveBeenCalledTimes(1);
-
-        const agentMessages = Array.from(
-            element.shadowRoot.querySelectorAll('div[data-role="agent"] .message-body')
-        ).map((node) => node.textContent);
-
-        expect(agentMessages).toContain('返品・交換サポートへようこそ。');
-        expect(agentMessages).toContain('注文番号を入力してください。');
-    });
-
     it('builds the messages endpoint from configured metadata when the session response omits URLs', async () => {
         const element = createElement('c-agentforce-chat', {
             is: AgentforceChat
@@ -308,6 +299,8 @@ describe('c-agentforce-chat', () => {
                 'https://api.salesforce.com/einstein/ai-agent/v1/sessions/{0}/messages',
             botId: 'bot-123'
         });
+
+        await flushPromises();
 
         mockStartSession.mockResolvedValue({
             sessionId: 'session-789'
@@ -364,6 +357,8 @@ describe('c-agentforce-chat', () => {
             botId: 'ignored-bot'
         });
 
+        await flushPromises();
+
         mockStartSession.mockResolvedValue({
             sessionId: 'session-456'
         });
@@ -413,6 +408,8 @@ describe('c-agentforce-chat', () => {
             botId: 'default-bot'
         });
 
+        await flushPromises();
+
         mockStartSession.mockResolvedValue({
             sessionId: 'session-999',
             messagesUrl: 'https://example.com/api/sessions/session-999/messages'
@@ -446,20 +443,6 @@ describe('c-agentforce-chat', () => {
 
         expect(agentMessages[0]).toBe(DEFAULT_START_SESSION_NOTICE);
         expect(agentMessages[agentMessages.length - 1]).toBe('Acknowledged');
-    });
-
-    it('prefills the composer when prefillDraftMessage is invoked', async () => {
-        const element = createElement('c-agentforce-chat', {
-            is: AgentforceChat
-        });
-        document.body.appendChild(element);
-
-        element.prefillDraftMessage('00099999');
-
-        await flushPromises();
-
-        const textarea = element.shadowRoot.querySelector('lightning-textarea');
-        expect(textarea.value).toBe('00099999');
     });
 
     it('prefills the composer when prefillDraftMessage is invoked', async () => {

--- a/force-app/main/default/lwc/agentforceChat/agentforceChat.js
+++ b/force-app/main/default/lwc/agentforceChat/agentforceChat.js
@@ -31,6 +31,7 @@ export default class AgentforceChat extends LightningElement {
 
     set startSessionEndpointUrl(value) {
         this._startSessionEndpointUrl = value;
+        this.resolveConfigReady();
     }
 
     @api
@@ -39,7 +40,8 @@ export default class AgentforceChat extends LightningElement {
     }
 
     set endpointUrl(value) {
-        this.startSessionEndpointUrl = value;
+        this._startSessionEndpointUrl = value;
+        this.resolveConfigReady();
     }
 
     @api
@@ -72,6 +74,8 @@ export default class AgentforceChat extends LightningElement {
     sessionInitializationPromise;
 
     wiredConfig;
+    _configReadyPromise;
+    _configReadyResolver;
 
     @wire(getConfig)
     wiredGetConfig(value) {
@@ -81,9 +85,9 @@ export default class AgentforceChat extends LightningElement {
             this.applyConfig(data);
         } else if (error) {
             this.errorMessage = 'Configuration error';
-            // eslint-disable-next-line no-console
             console.error('AgentforceChat configuration error', error);
         }
+        this.resolveConfigReady();
     }
 
     renderedCallback() {
@@ -266,7 +270,7 @@ export default class AgentforceChat extends LightningElement {
         let normalized;
         try {
             normalized = JSON.parse(JSON.stringify(result));
-        } catch (error) {
+        } catch {
             normalized = { ...result };
         }
 
@@ -316,8 +320,11 @@ export default class AgentforceChat extends LightningElement {
         }
 
         if (this.sessionInitializationPromise) {
-            return this.sessionInitializationPromise;
+            await this.sessionInitializationPromise;
+            return;
         }
+
+        await this.waitForConfig();
 
         const botId = this.resolvedBotId;
         if (!botId) {
@@ -356,6 +363,31 @@ export default class AgentforceChat extends LightningElement {
         this.ensureDefaultNoticeMessage();
     }
 
+    waitForConfig() {
+        if (
+            this.resolvedStartSessionEndpoint ||
+            (this.wiredConfig && (this.wiredConfig.data || this.wiredConfig.error))
+        ) {
+            return Promise.resolve();
+        }
+
+        if (!this._configReadyPromise) {
+            this._configReadyPromise = new Promise((resolve) => {
+                this._configReadyResolver = resolve;
+            });
+        }
+
+        return this._configReadyPromise;
+    }
+
+    resolveConfigReady() {
+        if (this._configReadyResolver) {
+            this._configReadyResolver();
+            this._configReadyResolver = undefined;
+            this._configReadyPromise = undefined;
+        }
+    }
+
     buildStartSessionEndpoint(template, botId) {
         if (!template) {
             return template;
@@ -382,10 +414,6 @@ export default class AgentforceChat extends LightningElement {
         const sessionKey = this.sessionKey || this.generateExternalSessionKey();
         const payload = {
             externalSessionKey: sessionKey,
-            instanceConfig: {
-                endpoint: this.resolvedInstanceEndpoint
-            },
-            tz: USER_TIMEZONE || this.getBrowserTimeZone(),
             variables: [
                 {
                     name: '$Context.EndUserLanguage',
@@ -408,6 +436,19 @@ export default class AgentforceChat extends LightningElement {
                 chunkTypes: ['Text']
             }
         };
+
+        const instanceEndpoint = this.resolvedInstanceEndpoint;
+        if (instanceEndpoint) {
+            payload.instanceConfig = {
+                endpoint: instanceEndpoint
+            };
+        }
+
+        const timezone = USER_TIMEZONE || this.getBrowserTimeZone();
+        if (timezone) {
+            payload.tz = timezone;
+        }
+
         return payload;
     }
 
@@ -520,7 +561,7 @@ export default class AgentforceChat extends LightningElement {
     getBrowserTimeZone() {
         try {
             return Intl.DateTimeFormat().resolvedOptions().timeZone;
-        } catch (error) {
+        } catch {
             return 'UTC';
         }
     }
@@ -667,7 +708,7 @@ export default class AgentforceChat extends LightningElement {
 
         try {
             return JSON.parse(value);
-        } catch (error) {
+        } catch {
             return undefined;
         }
     }
@@ -796,9 +837,9 @@ export default class AgentforceChat extends LightningElement {
         const statusId = this.statusMessageId;
         const replacement = this.createMessage('agent', content, variant);
 
-        this.messages = this.messages.map((message) =>
-            message.id === statusId ? { ...replacement, id: statusId } : message
-        );
+        this.messages = this.messages.map((message) => {
+            return message.id === statusId ? { ...replacement, id: statusId } : message;
+        });
 
         if (finalize) {
             this.statusMessageId = undefined;
@@ -812,9 +853,9 @@ export default class AgentforceChat extends LightningElement {
         }
 
         const statusId = this.statusMessageId;
-        this.messages = this.messages.map((existing) =>
-            existing.id === statusId ? { ...message, id: statusId } : existing
-        );
+        this.messages = this.messages.map((existing) => {
+            return existing.id === statusId ? { ...message, id: statusId } : existing;
+        });
         this.statusMessageId = undefined;
     }
 

--- a/force-app/main/default/lwc/purchaseHistory/__tests__/purchaseHistory.test.js
+++ b/force-app/main/default/lwc/purchaseHistory/__tests__/purchaseHistory.test.js
@@ -16,20 +16,15 @@ jest.mock(
       focusComposerMock,
       applySessionResultMock,
       default: class AgentforceChatStub extends LightningElement {
-        initializeConversation(...args) {
-          return initializeConversationMock(...args);
-        }
-
-        prefillDraftMessage(...args) {
-          return prefillDraftMessageMock(...args);
-        }
-
-        focusComposer(...args) {
-          return focusComposerMock(...args);
-        }
-
-        applySessionResult(...args) {
-          return applySessionResultMock(...args);
+        constructor() {
+          super();
+          this.initializeConversation = (...args) =>
+            initializeConversationMock(...args);
+          this.prefillDraftMessage = (...args) =>
+            prefillDraftMessageMock(...args);
+          this.focusComposer = (...args) => focusComposerMock(...args);
+          this.applySessionResult = (...args) =>
+            applySessionResultMock(...args);
         }
       }
     };


### PR DESCRIPTION
## Summary
- flatten the Apex start-session defaults so the request uses top-level instance, timezone, streaming, and variable fields while still migrating any legacy `sessionConfig` overrides
- update the Agentforce chat LWC to emit the flattened payload shape and adjust unit tests to expect the new structure

## Testing
- `npm test` *(fails: `sfdx-lwc-jest` is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_690968535cfc832ca0b4192437609cda