### PR TITLE
Remove default agentforce notice message

### DIFF
--- a/force-app/main/default/lwc/agentforceChat/__tests__/agentforceChat.test.js
+++ b/force-app/main/default/lwc/agentforceChat/__tests__/agentforceChat.test.js
@@ -65,10 +65,6 @@ const flushPromises = () =>
             })
     );
 
-const DEFAULT_START_SESSION_NOTICE = `こんにちは。NovaRigel返品エージェントです。
-ご購入商品の返品や交換に関するご相談をサポートいたします。
-注文番号をお持ちの場合は、まず注文番号を入力してください。`;
-
 describe('c-agentforce-chat', () => {
     afterEach(() => {
         while (document.body.firstChild) {
@@ -158,8 +154,7 @@ describe('c-agentforce-chat', () => {
             element.shadowRoot.querySelectorAll('div[data-role="agent"] .message-body')
         ).map((node) => node.textContent);
 
-        expect(agentMessages[0]).toBe(DEFAULT_START_SESSION_NOTICE);
-        expect(agentMessages[agentMessages.length - 1]).toBe('Hello from Agentforce');
+        expect(agentMessages[0]).toBe('Hello from Agentforce');
     });
 
     it('shows error state when the Agentforce call fails', async () => {
@@ -206,8 +201,7 @@ describe('c-agentforce-chat', () => {
             element.shadowRoot.querySelectorAll('div[data-role="agent"] .message-body')
         ).map((node) => node.textContent);
 
-        expect(agentMessages[0]).toBe(DEFAULT_START_SESSION_NOTICE);
-        expect(agentMessages).toContain('Agentforce request failed');
+        expect(agentMessages[0]).toBe('Agentforce request failed');
     });
 
     it('initializes the session and renders notice messages from the start session response', async () => {
@@ -249,12 +243,11 @@ describe('c-agentforce-chat', () => {
             element.shadowRoot.querySelectorAll('div[data-role="agent"] .message-body')
         ).map((node) => node.textContent);
 
-        expect(agentMessages[0]).toBe(DEFAULT_START_SESSION_NOTICE);
         expect(agentMessages).toContain('返品・交換サポートへようこそ。');
         expect(agentMessages).toContain('注文番号を入力してください。');
     });
 
-    it('adds the default notice message when no initial messages are returned', async () => {
+    it('does not add a default notice message when no initial messages are returned', async () => {
         const element = createElement('c-agentforce-chat', {
             is: AgentforceChat
         });
@@ -281,8 +274,7 @@ describe('c-agentforce-chat', () => {
             element.shadowRoot.querySelectorAll('div[data-role="agent"] .message-body')
         ).map((node) => node.textContent);
 
-        expect(agentMessages).toHaveLength(1);
-        expect(agentMessages[0]).toBe(DEFAULT_START_SESSION_NOTICE);
+        expect(agentMessages).toHaveLength(0);
     });
 
     it('builds the messages endpoint from configured metadata when the session response omits URLs', async () => {
@@ -441,8 +433,7 @@ describe('c-agentforce-chat', () => {
             element.shadowRoot.querySelectorAll('div[data-role="agent"] .message-body')
         ).map((node) => node.textContent);
 
-        expect(agentMessages[0]).toBe(DEFAULT_START_SESSION_NOTICE);
-        expect(agentMessages[agentMessages.length - 1]).toBe('Acknowledged');
+        expect(agentMessages[0]).toBe('Acknowledged');
     });
 
     it('prefills the composer when prefillDraftMessage is invoked', async () => {

--- a/force-app/main/default/lwc/agentforceChat/agentforceChat.js
+++ b/force-app/main/default/lwc/agentforceChat/agentforceChat.js
@@ -15,10 +15,6 @@ const STATUS = {
     SENDING: 'Sending message…'
 };
 
-const DEFAULT_START_SESSION_NOTICE = `こんにちは。NovaRigel返品エージェントです。
-ご購入商品の返品や交換に関するご相談をサポートいたします。
-注文番号をお持ちの場合は、まず注文番号を入力してください。`;
-
 export default class AgentforceChat extends LightningElement {
     _startSessionEndpointUrl;
     _messagesEndpointUrl;
@@ -192,7 +188,6 @@ export default class AgentforceChat extends LightningElement {
         }
 
         this.appendInitialMessagesFromStartSession(normalizedResult);
-        this.ensureDefaultNoticeMessage();
     }
 
     async handleSend() {
@@ -360,7 +355,6 @@ export default class AgentforceChat extends LightningElement {
         this.sessionKey = result?.externalSessionKey || payload.externalSessionKey;
         this.messagesEndpoint = this.resolveMessagesEndpoint(result, sessionId, startSessionEndpoint);
         this.appendInitialMessagesFromStartSession(result);
-        this.ensureDefaultNoticeMessage();
     }
 
     waitForConfig() {
@@ -869,24 +863,4 @@ export default class AgentforceChat extends LightningElement {
         this.statusMessageId = undefined;
     }
 
-    ensureDefaultNoticeMessage() {
-        const existingIndex = this.messages.findIndex(
-            (message) => message.role === 'agent' && message.content === DEFAULT_START_SESSION_NOTICE
-        );
-
-        if (existingIndex === 0) {
-            return;
-        }
-
-        if (existingIndex > 0) {
-            const existing = this.messages[existingIndex];
-            const before = this.messages.slice(0, existingIndex);
-            const after = this.messages.slice(existingIndex + 1);
-            this.messages = [existing, ...before, ...after];
-            return;
-        }
-
-        const noticeMessage = this.createMessage('agent', DEFAULT_START_SESSION_NOTICE, 'type-notice');
-        this.messages = [noticeMessage, ...this.messages];
-    }
 }


### PR DESCRIPTION
## Summary
- remove the hard-coded Agentforce notice message that was prepended to every chat transcript
- update unit tests to reflect the absence of the default notice and ensure initial messages only include real responses

## Testing
- npm test -- --runTestsByPath force-app/main/default/lwc/agentforceChat/__tests__/agentforceChat.test.js *(fails: `sfdx-lwc-jest` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_6909ffaa7628832c91c348c7965e8ac9