### PR TITLE
Refactor purchase history retrieval for buyer contact

### DIFF
--- a/force-app/main/default/classes/PurchaseHistoryController.cls
+++ b/force-app/main/default/classes/PurchaseHistoryController.cls
@@ -1,68 +1,156 @@
 /**
- * @description       : 
+ * @description       :
  * @author            : ChangeMeIn@UserSettingsUnder.SFDoc
- * @group             : 
+ * @group             :
  * @last modified on  : 10-01-2025
  * @last modified by  : ChangeMeIn@UserSettingsUnder.SFDoc
-**/
+ **/
 public with sharing class PurchaseHistoryController {
-    public class PurchaseHistoryItem {
-        @AuraEnabled public Id orderId { get; set; }
-        @AuraEnabled public String orderNumber { get; set; }
-        @AuraEnabled public Date purchaseDate { get; set; }
-        @AuraEnabled public String status { get; set; }
-        @AuraEnabled public Id orderItemId { get; set; }
-        @AuraEnabled public Decimal quantity { get; set; }
-        @AuraEnabled public Decimal unitPrice { get; set; }
-        @AuraEnabled public Decimal totalPrice { get; set; }
-        @AuraEnabled public String productName { get; set; }
-        @AuraEnabled public String productCode { get; set; }
-        @AuraEnabled public String productDescription { get; set; }
-        // @AuraEnabled public String currencyIsoCode { get; set; }
+  public class PurchaseHistoryItem {
+    @AuraEnabled
+    public Id orderId { get; set; }
+    @AuraEnabled
+    public String orderNumber { get; set; }
+    @AuraEnabled
+    public Date purchaseDate { get; set; }
+    @AuraEnabled
+    public String status { get; set; }
+    @AuraEnabled
+    public Id orderItemId { get; set; }
+    @AuraEnabled
+    public Decimal quantity { get; set; }
+    @AuraEnabled
+    public Decimal unitPrice { get; set; }
+    @AuraEnabled
+    public Decimal totalPrice { get; set; }
+    @AuraEnabled
+    public String productName { get; set; }
+    @AuraEnabled
+    public String productCode { get; set; }
+    @AuraEnabled
+    public String productDescription { get; set; }
+  }
+
+  public class PurchaseHistoryOrder {
+    @AuraEnabled
+    public Id orderId { get; set; }
+    @AuraEnabled
+    public String orderNumber { get; set; }
+    @AuraEnabled
+    public Date purchaseDate { get; set; }
+    @AuraEnabled
+    public String status { get; set; }
+    @AuraEnabled
+    public String currencyIsoCode { get; set; }
+    @AuraEnabled
+    public Decimal totalPrice { get; set; }
+    @AuraEnabled
+    public List<PurchaseHistoryItem> items { get; set; }
+
+    public PurchaseHistoryOrder() {
+      items = new List<PurchaseHistoryItem>();
+      totalPrice = 0;
+    }
+  }
+
+  @AuraEnabled(cacheable=true)
+  public static List<PurchaseHistoryOrder> getPurchaseHistory() {
+    List<User> users = [
+      SELECT ContactId
+      FROM User
+      WHERE Id = :UserInfo.getUserId()
+      LIMIT 1
+    ];
+
+    if (users.isEmpty() || users[0].ContactId == null) {
+      return new List<PurchaseHistoryOrder>();
     }
 
-    @AuraEnabled(cacheable=true)
-    public static List<PurchaseHistoryItem> getPurchaseHistory(Id accountId) {
-        if (accountId == null) {
-            throw new AuraHandledException('An account Id is required to view purchase history.');
-        }
+    Id contactId = users[0].ContactId;
 
-        List<OrderItem> orderItems = [
-            SELECT Id,
-                   OrderId,
-                   Order.OrderNumber,
-                   Order.EffectiveDate,
-                   Order.Status,
-                //    Order.CurrencyIsoCode,
-                   Quantity,
-                   UnitPrice,
-                   TotalPrice,
-                   Product2.Name,
-                   Product2.ProductCode,
-                   Product2.Description
-            FROM OrderItem
-            WHERE Order.AccountId = :accountId
-            ORDER BY Order.EffectiveDate DESC, Order.OrderNumber DESC
-        ];
+    List<OrderItem> orderItems = [
+      SELECT
+        Id,
+        OrderId,
+        Order.OrderNumber,
+        Order.EffectiveDate,
+        Order.Status,
+        Order.CurrencyIsoCode,
+        Quantity,
+        UnitPrice,
+        TotalPrice,
+        Product2.Name,
+        Product2.ProductCode,
+        Product2.Description
+      FROM OrderItem
+      WHERE Order.BillToContactId = :contactId
+      ORDER BY
+        Order.EffectiveDate DESC,
+        Order.OrderNumber DESC,
+        CreatedDate DESC
+    ];
 
-        List<PurchaseHistoryItem> results = new List<PurchaseHistoryItem>();
-        for (OrderItem item : orderItems) {
-            PurchaseHistoryItem historyItem = new PurchaseHistoryItem();
-            historyItem.orderId = item.OrderId;
-            historyItem.orderNumber = item.Order.OrderNumber;
-            historyItem.purchaseDate = item.Order.EffectiveDate;
-            historyItem.status = item.Order.Status;
-            historyItem.orderItemId = item.Id;
-            historyItem.quantity = item.Quantity;
-            historyItem.unitPrice = item.UnitPrice;
-            historyItem.totalPrice = item.TotalPrice;
-            historyItem.productName = item.Product2 != null ? item.Product2.Name : null;
-            historyItem.productCode = item.Product2 != null ? item.Product2.ProductCode : null;
-            historyItem.productDescription = item.Product2 != null ? item.Product2.Description : null;
-            // historyItem.currencyIsoCode = item.Order.CurrencyIsoCode;
-            results.add(historyItem);
-        }
+    Map<Id, PurchaseHistoryOrder> ordersById = new Map<Id, PurchaseHistoryOrder>();
+    List<Id> orderSequence = new List<Id>();
 
-        return results;
+    for (OrderItem item : orderItems) {
+      if (item.OrderId == null) {
+        continue;
+      }
+
+      if (!ordersById.containsKey(item.OrderId)) {
+        PurchaseHistoryOrder order = new PurchaseHistoryOrder();
+        order.orderId = item.OrderId;
+        order.orderNumber = item.Order != null ? item.Order.OrderNumber : null;
+        order.purchaseDate = item.Order != null
+          ? item.Order.EffectiveDate
+          : null;
+        order.status = item.Order != null ? item.Order.Status : null;
+        order.currencyIsoCode = item.Order != null
+          ? item.Order.CurrencyIsoCode
+          : null;
+        ordersById.put(order.orderId, order);
+        orderSequence.add(order.orderId);
+      }
+
+      PurchaseHistoryOrder existingOrder = ordersById.get(item.OrderId);
+
+      PurchaseHistoryItem historyItem = new PurchaseHistoryItem();
+      historyItem.orderId = item.OrderId;
+      historyItem.orderNumber = item.Order != null
+        ? item.Order.OrderNumber
+        : null;
+      historyItem.purchaseDate = item.Order != null
+        ? item.Order.EffectiveDate
+        : null;
+      historyItem.status = item.Order != null ? item.Order.Status : null;
+      historyItem.orderItemId = item.Id;
+      historyItem.quantity = item.Quantity;
+      historyItem.unitPrice = item.UnitPrice;
+      historyItem.totalPrice = item.TotalPrice;
+      historyItem.productName = item.Product2 != null
+        ? item.Product2.Name
+        : null;
+      historyItem.productCode = item.Product2 != null
+        ? item.Product2.ProductCode
+        : null;
+      historyItem.productDescription = item.Product2 != null
+        ? item.Product2.Description
+        : null;
+
+      existingOrder.items.add(historyItem);
+      if (item.TotalPrice != null) {
+        existingOrder.totalPrice += item.TotalPrice;
+      }
     }
+
+    List<PurchaseHistoryOrder> results = new List<PurchaseHistoryOrder>();
+    for (Id orderId : orderSequence) {
+      if (ordersById.containsKey(orderId)) {
+        results.add(ordersById.get(orderId));
+      }
+    }
+
+    return results;
+  }
 }

--- a/force-app/main/default/classes/PurchaseHistoryControllerTest.cls
+++ b/force-app/main/default/classes/PurchaseHistoryControllerTest.cls
@@ -1,63 +1,192 @@
 @IsTest
 private class PurchaseHistoryControllerTest {
-    @IsTest
-    static void testGetPurchaseHistory() {
-        Account account = new Account(Name = 'Test Account');
-        insert account;
+  @IsTest
+  static void testGetPurchaseHistory() {
+    Account account = new Account(Name = 'Test Account');
+    insert account;
 
-        Pricebook2 standardPricebook = [SELECT Id FROM Pricebook2 WHERE IsStandard = true LIMIT 1];
+    Contact contact = new Contact(
+      FirstName = 'Test',
+      LastName = 'Buyer',
+      AccountId = account.Id,
+      Email = 'test-buyer@example.com'
+    );
+    insert contact;
 
-        Product2 product = new Product2(Name = 'Test Product', ProductCode = 'TP-001', isActive = true);
-        insert product;
+    Profile standardProfile = [
+      SELECT Id
+      FROM Profile
+      WHERE Name = 'Standard User'
+      LIMIT 1
+    ];
 
-        PricebookEntry pricebookEntry = new PricebookEntry(
-            Pricebook2Id = standardPricebook.Id,
-            Product2Id = product.Id,
-            UnitPrice = 100,
-            IsActive = true
-        );
-        insert pricebookEntry;
+    User buyer = new User(
+      Alias = 'tbuyer',
+      Email = 'test-buyer@example.com',
+      EmailEncodingKey = 'UTF-8',
+      LastName = 'Buyer',
+      LanguageLocaleKey = 'en_US',
+      LocaleSidKey = 'en_US',
+      TimeZoneSidKey = 'America/Los_Angeles',
+      Username = 'test-buyer' + DateTime.now().getTime() + '@example.com',
+      ProfileId = standardProfile.Id,
+      ContactId = contact.Id
+    );
+    insert buyer;
 
-        Order orderRecord = new Order(
-            AccountId = account.Id,
-            EffectiveDate = Date.today(),
-            Status = 'Draft',
-            Pricebook2Id = standardPricebook.Id
-        );
-        insert orderRecord;
+    Pricebook2 standardPricebook = [
+      SELECT Id
+      FROM Pricebook2
+      WHERE IsStandard = TRUE
+      LIMIT 1
+    ];
 
-        OrderItem orderItem = new OrderItem(
-            OrderId = orderRecord.Id,
-            PricebookEntryId = pricebookEntry.Id,
-            Quantity = 2,
-            UnitPrice = 100
-        );
-        insert orderItem;
+    Product2 product = new Product2(
+      Name = 'Test Product',
+      ProductCode = 'TP-001',
+      isActive = true
+    );
+    insert product;
 
-        Test.startTest();
-        List<PurchaseHistoryController.PurchaseHistoryItem> history = PurchaseHistoryController.getPurchaseHistory(account.Id);
-        Test.stopTest();
+    PricebookEntry pricebookEntry = new PricebookEntry(
+      Pricebook2Id = standardPricebook.Id,
+      Product2Id = product.Id,
+      UnitPrice = 100,
+      IsActive = true
+    );
+    insert pricebookEntry;
 
-        System.assertEquals(1, history.size(), 'A single order item should be returned.');
-        PurchaseHistoryController.PurchaseHistoryItem item = history[0];
-        System.assertEquals(orderRecord.Id, item.orderId, 'Order Id should match.');
-        System.assertEquals(orderItem.Id, item.orderItemId, 'Order item Id should match.');
-        System.assertEquals(product.Name, item.productName, 'Product name should match.');
-        System.assertEquals(product.ProductCode, item.productCode, 'Product code should match.');
-        System.assertEquals(orderItem.Quantity, item.quantity, 'Quantity should match.');
-        System.assertEquals(orderItem.UnitPrice, item.unitPrice, 'Unit price should match.');
-        System.assertEquals(orderItem.TotalPrice, item.totalPrice, 'Total price should match.');
+    System.runAs(buyer) {
+      Order orderRecord = new Order(
+        AccountId = account.Id,
+        BillToContactId = contact.Id,
+        EffectiveDate = Date.today(),
+        Status = 'Draft',
+        Pricebook2Id = standardPricebook.Id
+      );
+      insert orderRecord;
+
+      OrderItem orderItem = new OrderItem(
+        OrderId = orderRecord.Id,
+        PricebookEntryId = pricebookEntry.Id,
+        Quantity = 2,
+        UnitPrice = 100
+      );
+      insert orderItem;
+
+      Test.startTest();
+      List<PurchaseHistoryController.PurchaseHistoryOrder> history = PurchaseHistoryController.getPurchaseHistory();
+      Test.stopTest();
+
+      System.assertEquals(
+        1,
+        history.size(),
+        'A single order should be returned.'
+      );
+
+      PurchaseHistoryController.PurchaseHistoryOrder order = history[0];
+      System.assertEquals(
+        orderRecord.Id,
+        order.orderId,
+        'Order Id should match.'
+      );
+      System.assertEquals(
+        orderRecord.OrderNumber,
+        order.orderNumber,
+        'Order number should match.'
+      );
+      System.assertEquals(
+        orderRecord.EffectiveDate,
+        order.purchaseDate,
+        'Purchase date should match.'
+      );
+      System.assertEquals(
+        orderRecord.Status,
+        order.status,
+        'Status should match.'
+      );
+      System.assertEquals(
+        order.totalPrice,
+        orderItem.TotalPrice,
+        'Total price should match order item total.'
+      );
+      System.assertEquals(
+        1,
+        order.items.size(),
+        'Single order item should be grouped under the order.'
+      );
+
+      PurchaseHistoryController.PurchaseHistoryItem item = order.items[0];
+      System.assertEquals(
+        orderRecord.Id,
+        item.orderId,
+        'Order Id on item should match.'
+      );
+      System.assertEquals(
+        orderItem.Id,
+        item.orderItemId,
+        'Order item Id should match.'
+      );
+      System.assertEquals(
+        product.Name,
+        item.productName,
+        'Product name should match.'
+      );
+      System.assertEquals(
+        product.ProductCode,
+        item.productCode,
+        'Product code should match.'
+      );
+      System.assertEquals(
+        orderItem.Quantity,
+        item.quantity,
+        'Quantity should match.'
+      );
+      System.assertEquals(
+        orderItem.UnitPrice,
+        item.unitPrice,
+        'Unit price should match.'
+      );
+      System.assertEquals(
+        orderItem.TotalPrice,
+        item.totalPrice,
+        'Total price should match.'
+      );
     }
+  }
 
-    @IsTest
-    static void testGetPurchaseHistoryRequiresAccountId() {
-        Test.startTest();
-        try {
-            PurchaseHistoryController.getPurchaseHistory(null);
-            System.assert(false, 'Method should throw an error when account Id is not provided.');
-        } catch (AuraHandledException e) {
-            System.assertEquals('An account Id is required to view purchase history.', e.getMessage());
-        }
-        Test.stopTest();
+  @IsTest
+  static void testGetPurchaseHistoryWithoutContact() {
+    Profile standardProfile = [
+      SELECT Id
+      FROM Profile
+      WHERE Name = 'Standard User'
+      LIMIT 1
+    ];
+
+    User buyerWithoutContact = new User(
+      Alias = 'ncnuser',
+      Email = 'no-contact@example.com',
+      EmailEncodingKey = 'UTF-8',
+      LastName = 'User',
+      LanguageLocaleKey = 'en_US',
+      LocaleSidKey = 'en_US',
+      TimeZoneSidKey = 'America/Los_Angeles',
+      Username = 'no-contact' + DateTime.now().getTime() + '@example.com',
+      ProfileId = standardProfile.Id
+    );
+    insert buyerWithoutContact;
+
+    System.runAs(buyerWithoutContact) {
+      Test.startTest();
+      List<PurchaseHistoryController.PurchaseHistoryOrder> history = PurchaseHistoryController.getPurchaseHistory();
+      Test.stopTest();
+
+      System.assertEquals(
+        0,
+        history.size(),
+        'No orders should be returned for users without a contact.'
+      );
     }
+  }
 }

--- a/force-app/main/default/lwc/purchaseHistory/__tests__/purchaseHistory.test.js
+++ b/force-app/main/default/lwc/purchaseHistory/__tests__/purchaseHistory.test.js
@@ -4,29 +4,45 @@ import PurchaseHistory from "c/purchaseHistory";
 jest.mock(
   "c/agentforceChat",
   () => {
-    const { LightningElement } = require("lwc");
+    const { LightningElement, registerDecorators } = require("lwc");
     const initializeConversationMock = jest.fn().mockResolvedValue();
     const prefillDraftMessageMock = jest.fn();
     const focusComposerMock = jest.fn();
     const applySessionResultMock = jest.fn().mockResolvedValue();
+    class AgentforceChatStub extends LightningElement {
+      initializeConversation(...args) {
+        return initializeConversationMock(...args);
+      }
+
+      prefillDraftMessage(...args) {
+        return prefillDraftMessageMock(...args);
+      }
+
+      focusComposer(...args) {
+        return focusComposerMock(...args);
+      }
+
+      applySessionResult(...args) {
+        return applySessionResultMock(...args);
+      }
+    }
+
+    registerDecorators(AgentforceChatStub, {
+      publicMethods: [
+        "initializeConversation",
+        "prefillDraftMessage",
+        "focusComposer",
+        "applySessionResult"
+      ]
+    });
+
     return {
       __esModule: true,
       initializeConversationMock,
       prefillDraftMessageMock,
       focusComposerMock,
       applySessionResultMock,
-      default: class AgentforceChatStub extends LightningElement {
-        constructor() {
-          super();
-          this.initializeConversation = (...args) =>
-            initializeConversationMock(...args);
-          this.prefillDraftMessage = (...args) =>
-            prefillDraftMessageMock(...args);
-          this.focusComposer = (...args) => focusComposerMock(...args);
-          this.applySessionResult = (...args) =>
-            applySessionResultMock(...args);
-        }
-      }
+      default: AgentforceChatStub
     };
   },
   { virtual: true }
@@ -68,7 +84,8 @@ jest.mock(
   { virtual: true }
 );
 
-const startSessionMock = require("@salesforce/apex/AgentforceChatController.startSession").default;
+const startSessionMock =
+  require("@salesforce/apex/AgentforceChatController.startSession").default;
 
 async function flushPromises(iterations = 1) {
   for (let index = 0; index < iterations; index += 1) {
@@ -139,7 +156,9 @@ describe("c-purchase-history", () => {
     expect(startSessionMock).toHaveBeenCalledWith(
       expect.objectContaining({
         payload: expect.objectContaining({
-          context: expect.objectContaining({ orderNumber: "00012345" })
+          context: expect.objectContaining({
+            orderNumber: "注文番号は「00012345」です"
+          })
         })
       })
     );
@@ -153,7 +172,9 @@ describe("c-purchase-history", () => {
     );
 
     expect(initializeConversationMock).toHaveBeenCalledTimes(1);
-    expect(prefillDraftMessageMock).toHaveBeenCalledWith("00012345");
+    expect(prefillDraftMessageMock).toHaveBeenCalledWith(
+      "注文番号は「00012345」です"
+    );
     expect(focusComposerMock).toHaveBeenCalled();
   });
 

--- a/force-app/main/default/lwc/purchaseHistory/purchaseHistory.js
+++ b/force-app/main/default/lwc/purchaseHistory/purchaseHistory.js
@@ -4,7 +4,6 @@ import startAgentforceSession from "@salesforce/apex/AgentforceChatController.st
 import { ShowToastEvent } from "lightning/platformShowToastEvent";
 
 export default class PurchaseHistory extends LightningElement {
-  @api recordId = "001gK00000NYz8gQAD";
   orders = [];
   error;
   isLoading = false;
@@ -31,8 +30,9 @@ export default class PurchaseHistory extends LightningElement {
   }
 
   get agentforceChatContainerClass() {
-    return `agentforce-chat-container${this.isAgentforceChatVisible ? " agentforce-chat-container--visible" : ""
-      }`;
+    return `agentforce-chat-container${
+      this.isAgentforceChatVisible ? " agentforce-chat-container--visible" : ""
+    }`;
   }
 
   get agentforceChatAriaHidden() {
@@ -48,20 +48,13 @@ export default class PurchaseHistory extends LightningElement {
   }
 
   async loadPurchaseHistory() {
-    if (!this.recordId) {
-      this.error = {
-        message: "購入履歴を表示するには取引先のレコードIDが必要です。"
-      };
-      return;
-    }
-
     this.isLoading = true;
     this.error = undefined;
     this.orders = [];
 
     try {
-      const history = await getPurchaseHistory({ accountId: this.recordId });
-      this.orders = this.groupHistoryByOrder(history || []);
+      const history = await getPurchaseHistory();
+      this.orders = this.normalizeOrders(history || []);
     } catch (error) {
       this.error = error;
       this.dispatchEvent(
@@ -146,8 +139,7 @@ export default class PurchaseHistory extends LightningElement {
   }
 
   async requestAgentforceSession(orderNumber) {
-    // const payload = this.buildAgentforceSessionPayload(orderNumber);
-    const payload = null;
+    const payload = this.buildAgentforceSessionPayload(orderNumber);
     const result = await startAgentforceSession({ payload });
     return this.normalizeAgentforceSessionResult(result);
   }
@@ -194,7 +186,7 @@ export default class PurchaseHistory extends LightningElement {
     if (typeof structuredClone === "function") {
       try {
         return structuredClone(value);
-      } catch (error) {
+      } catch {
         // Ignore structured clone errors and fall back to other strategies.
       }
     }
@@ -205,14 +197,14 @@ export default class PurchaseHistory extends LightningElement {
     ) {
       try {
         return window.structuredClone(value);
-      } catch (error) {
+      } catch {
         // Ignore structured clone errors and fall back to JSON parsing.
       }
     }
 
     try {
       return JSON.parse(JSON.stringify(value));
-    } catch (error) {
+    } catch {
       return value;
     }
   }
@@ -224,7 +216,7 @@ export default class PurchaseHistory extends LightningElement {
 
     try {
       return JSON.parse(value);
-    } catch (error) {
+    } catch {
       return undefined;
     }
   }
@@ -243,10 +235,7 @@ export default class PurchaseHistory extends LightningElement {
         return error.body.trim();
       }
 
-      if (
-        typeof error.body.message === "string" &&
-        error.body.message.trim()
-      ) {
+      if (typeof error.body.message === "string" && error.body.message.trim()) {
         return error.body.message.trim();
       }
     }
@@ -297,11 +286,20 @@ export default class PurchaseHistory extends LightningElement {
     }
 
     try {
-      if (
-        this.agentforceSessionResult &&
+      let applySessionResultFn =
         typeof chat.applySessionResult === "function"
-      ) {
-        await chat.applySessionResult(this.agentforceSessionResult);
+          ? chat.applySessionResult.bind(chat)
+          : null;
+
+      if (!applySessionResultFn) {
+        await Promise.resolve();
+        if (typeof chat.applySessionResult === "function") {
+          applySessionResultFn = chat.applySessionResult.bind(chat);
+        }
+      }
+
+      if (this.agentforceSessionResult && applySessionResultFn) {
+        await applySessionResultFn(this.agentforceSessionResult);
       }
 
       if (typeof chat.initializeConversation === "function") {
@@ -335,70 +333,65 @@ export default class PurchaseHistory extends LightningElement {
     this.agentforceSessionResult = undefined;
   }
 
-  groupHistoryByOrder(historyItems) {
-    if (!Array.isArray(historyItems) || historyItems.length === 0) {
+  normalizeOrders(orders) {
+    if (!Array.isArray(orders) || orders.length === 0) {
       return [];
     }
 
-    const ordersById = new Map();
+    return orders
+      .filter((order) => order && order.orderId)
+      .map((order) => {
+        const currencyIsoCode = order.currencyIsoCode || "JPY";
+        const items = Array.isArray(order.items) ? order.items : [];
+        let itemCount = 0;
+        let computedTotalPrice = 0;
 
-    historyItems.forEach((item) => {
-      const orderId = item.orderId;
-      if (!orderId) {
-        return;
-      }
+        const normalizedItems = items.map((item) => {
+          const hasQuantity =
+            item?.quantity !== null && item?.quantity !== undefined;
+          const quantity = hasQuantity
+            ? this.getNumericValue(item.quantity)
+            : null;
+          const unitPrice = this.getNumericValue(item.unitPrice);
+          const lineTotalPrice = this.getNumericValue(item.totalPrice);
+          const quantityForCount = hasQuantity && quantity > 0 ? quantity : 1;
+          itemCount += quantityForCount;
+          computedTotalPrice += lineTotalPrice;
 
-      if (!ordersById.has(orderId)) {
-        ordersById.set(orderId, {
-          orderId,
-          orderNumber: item.orderNumber,
-          purchaseDate: item.purchaseDate,
-          status: item.status,
-          currencyIsoCode: item.currencyIsoCode || "JPY",
-          totalPrice: 0,
-          items: [],
-          itemCount: 0
+          return {
+            orderItemId: item.orderItemId,
+            productName: item.productName || "商品名未設定",
+            productCode: item.productCode,
+            productDescription: this.formatDescription(item.productDescription),
+            quantityFormatted: hasQuantity ? this.formatNumber(quantity) : "",
+            unitPriceFormatted: this.formatCurrency(unitPrice, currencyIsoCode),
+            totalPriceFormatted: this.formatCurrency(
+              lineTotalPrice,
+              currencyIsoCode
+            ),
+            initial: this.getInitial(item.productName)
+          };
         });
-      }
 
-      const order = ordersById.get(orderId);
-      const hasQuantity = item.quantity !== null && item.quantity !== undefined;
-      const quantity = hasQuantity ? this.getNumericValue(item.quantity) : null;
-      const unitPrice = this.getNumericValue(item.unitPrice);
-      const totalPrice = this.getNumericValue(item.totalPrice);
+        const providedTotalPrice = this.getNumericValue(order.totalPrice);
+        const totalPrice =
+          providedTotalPrice > 0 ? providedTotalPrice : computedTotalPrice;
 
-      order.items.push({
-        orderItemId: item.orderItemId,
-        productName: item.productName || "商品名未設定",
-        productCode: item.productCode,
-        productDescription: this.formatDescription(item.productDescription),
-        quantityFormatted: hasQuantity ? this.formatNumber(quantity) : "",
-        unitPriceFormatted: this.formatCurrency(
-          unitPrice,
-          order.currencyIsoCode
-        ),
-        totalPriceFormatted: this.formatCurrency(
+        return {
+          orderId: order.orderId,
+          orderNumber: order.orderNumber,
+          purchaseDate: order.purchaseDate,
+          status: order.status,
+          currencyIsoCode,
           totalPrice,
-          order.currencyIsoCode
-        ),
-        initial: this.getInitial(item.productName)
+          items: normalizedItems,
+          itemCount,
+          purchaseDateFormatted: this.formatDate(order.purchaseDate),
+          totalPriceFormatted: this.formatCurrency(totalPrice, currencyIsoCode),
+          statusText: order.status || "不明",
+          itemCountText: this.formatItemCount(itemCount)
+        };
       });
-
-      order.totalPrice += totalPrice;
-      const quantityForCount = hasQuantity && quantity > 0 ? quantity : 1;
-      order.itemCount += quantityForCount;
-    });
-
-    return Array.from(ordersById.values()).map((order) => ({
-      ...order,
-      purchaseDateFormatted: this.formatDate(order.purchaseDate),
-      totalPriceFormatted: this.formatCurrency(
-        order.totalPrice,
-        order.currencyIsoCode
-      ),
-      statusText: order.status || "不明",
-      itemCountText: this.formatItemCount(order.itemCount)
-    }));
   }
 
   formatDate(value) {


### PR DESCRIPTION
## Summary
- query purchase history by resolving the logged-in user's contact and grouping order items under their parent orders
- extend the Apex tests to build contact-linked users, validate grouped order results, and cover the no-contact scenario
- adapt the LWC to consume the aggregated server response, keep Agentforce chat flows working, and expose public methods in the Jest stub

## Testing
- `npx sfdx-lwc-jest -- --runTestsByPath force-app/main/default/lwc/purchaseHistory/__tests__/purchaseHistory.test.js`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dedd4dd70832c99fe6bf6bc53b333)