### PR TITLE
Add LWC for Google Maps travel time lookup

### DIFF
--- a/force-app/main/default/classes/TravelTimeController.cls
+++ b/force-app/main/default/classes/TravelTimeController.cls
@@ -1,0 +1,150 @@
+public with sharing class TravelTimeController {
+  private static final List<String> SUPPORTED_MODES = new List<String>{
+    'driving',
+    'walking',
+    'transit'
+  };
+
+  public class TravelOption {
+    @AuraEnabled
+    public String mode;
+    @AuraEnabled
+    public String status;
+    @AuraEnabled
+    public String durationText;
+    @AuraEnabled
+    public Integer durationValue;
+    @AuraEnabled
+    public String errorMessage;
+  }
+
+  @AuraEnabled(cacheable=false)
+  public static List<TravelOption> getTravelTimes(
+    String origin,
+    String destination
+  ) {
+    if (String.isBlank(origin) || String.isBlank(destination)) {
+      throw new AuraHandledException('出発地と到着地は必須です。');
+    }
+
+    List<TravelOption> results = new List<TravelOption>();
+
+    for (String mode : SUPPORTED_MODES) {
+      results.add(fetchTravelTime(origin, destination, mode));
+    }
+
+    return results;
+  }
+
+  @TestVisible
+  private static TravelOption fetchTravelTime(
+    String origin,
+    String destination,
+    String mode
+  ) {
+    Http http = new Http();
+    HttpRequest request = new HttpRequest();
+    request.setMethod('GET');
+    request.setTimeout(20000);
+    request.setEndpoint(buildEndpoint(origin, destination, mode));
+
+    HttpResponse response = http.send(request);
+
+    TravelOption option = new TravelOption();
+    option.mode = mode;
+
+    if (response == null) {
+      option.status = 'ERROR';
+      option.errorMessage = 'Google Maps API からの応答がありません。';
+      return option;
+    }
+
+    if (response.getStatusCode() != 200) {
+      option.status = 'ERROR';
+      option.errorMessage =
+        'Google Maps API の呼び出しに失敗しました。ステータスコード：' +
+        response.getStatusCode();
+      return option;
+    }
+
+    Map<String, Object> payload = (Map<String, Object>) JSON.deserializeUntyped(
+      response.getBody()
+    );
+    option.status = (String) payload.get('status');
+
+    if (!'OK'.equalsIgnoreCase(option.status)) {
+      option.errorMessage = (String) payload.get('error_message');
+      if (String.isBlank(option.errorMessage)) {
+        option.errorMessage = 'Google Maps のステータス：' + option.status;
+      }
+      return option;
+    }
+
+    List<Object> rows = (List<Object>) payload.get('rows');
+    if (rows == null || rows.isEmpty()) {
+      option.status = 'ERROR';
+      option.errorMessage = '経路情報が返されませんでした。';
+      return option;
+    }
+
+    Map<String, Object> row = (Map<String, Object>) rows.get(0);
+    List<Object> elements = (List<Object>) row.get('elements');
+    if (elements == null || elements.isEmpty()) {
+      option.status = 'ERROR';
+      option.errorMessage = '経路情報が返されませんでした。';
+      return option;
+    }
+
+    Map<String, Object> element = (Map<String, Object>) elements.get(0);
+    String elementStatus = (String) element.get('status');
+    option.status = elementStatus;
+
+    if (!'OK'.equalsIgnoreCase(elementStatus)) {
+      option.errorMessage = 'Google Maps のステータス：' + elementStatus;
+      return option;
+    }
+
+    Map<String, Object> duration = (Map<String, Object>) element.get(
+      'duration'
+    );
+    if (duration != null) {
+      option.durationText = (String) duration.get('text');
+      Object valueObj = duration.get('value');
+      if (valueObj instanceof Integer) {
+        option.durationValue = (Integer) valueObj;
+      } else if (valueObj instanceof Long) {
+        option.durationValue = Integer.valueOf(((Long) valueObj).intValue());
+      }
+    }
+
+    return option;
+  }
+
+  private static String buildEndpoint(
+    String origin,
+    String destination,
+    String mode
+  ) {
+    String baseUrl = 'https://maps.googleapis.com/maps/api/distancematrix/json';
+    StringBuilder endpoint = new StringBuilder(baseUrl);
+    endpoint.append('?origins=' + EncodingUtil.urlEncode(origin, 'UTF-8'));
+    endpoint.append(
+      '&destinations=' + EncodingUtil.urlEncode(destination, 'UTF-8')
+    );
+    endpoint.append('&mode=' + EncodingUtil.urlEncode(mode, 'UTF-8'));
+    endpoint.append('&language=ja');
+    if ('transit'.equalsIgnoreCase(mode)) {
+      endpoint.append('&departure_time=now');
+    }
+
+    String apiKey = System.Label.Google_Maps_API_Key;
+    if (String.isBlank(apiKey)) {
+      throw new AuraHandledException(
+        'Google Maps API キーが設定されていません。カスタムラベル Google_Maps_API_Key に値を入力してください。'
+      );
+    }
+
+    endpoint.append('&key=' + EncodingUtil.urlEncode(apiKey, 'UTF-8'));
+    return endpoint.toString();
+  }
+}

--- a/force-app/main/default/classes/TravelTimeController.cls-meta.xml
+++ b/force-app/main/default/classes/TravelTimeController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/TravelTimeControllerTest.cls
+++ b/force-app/main/default/classes/TravelTimeControllerTest.cls
@@ -1,0 +1,77 @@
+@IsTest
+private class TravelTimeControllerTest {
+  private class DistanceMatrixMock implements HttpCalloutMock {
+    public HTTPResponse respond(HTTPRequest req) {
+      HttpResponse res = new HttpResponse();
+      res.setStatusCode(200);
+      res.setHeader('Content-Type', 'application/json');
+
+      String mode = 'unknown';
+      if (req.getEndpoint() != null) {
+        for (String param : req.getEndpoint().split('&')) {
+          if (param.startsWith('mode=')) {
+            mode = param.substring(5);
+            break;
+          }
+        }
+      }
+
+      String body = buildBody(mode);
+      res.setBody(body);
+      return res;
+    }
+
+    private String buildBody(String mode) {
+      Map<String, Object> duration = new Map<String, Object>{
+        'text' => '10 mins - ' + mode,
+        'value' => 600
+      };
+      Map<String, Object> element = new Map<String, Object>{
+        'status' => 'OK',
+        'duration' => duration
+      };
+      Map<String, Object> row = new Map<String, Object>{
+        'elements' => new List<Object>{ element }
+      };
+      Map<String, Object> payload = new Map<String, Object>{
+        'status' => 'OK',
+        'rows' => new List<Object>{ row }
+      };
+
+      return JSON.serialize(payload);
+    }
+  }
+
+  @IsTest
+  static void testGetTravelTimesSuccess() {
+    Test.setMock(HttpCalloutMock.class, new DistanceMatrixMock());
+
+    Test.startTest();
+    List<TravelTimeController.TravelOption> results = TravelTimeController.getTravelTimes(
+      'Beijing',
+      'Shanghai'
+    );
+    Test.stopTest();
+
+    System.assertEquals(
+      3,
+      results.size(),
+      'Should return travel time for each supported mode'
+    );
+    for (TravelTimeController.TravelOption option : results) {
+      System.assertEquals('OK', option.status);
+      System.assertNotEquals(null, option.durationText);
+      System.assertEquals(Integer.valueOf(600), option.durationValue);
+    }
+  }
+
+  @IsTest
+  static void testGetTravelTimesMissingAddress() {
+    try {
+      TravelTimeController.getTravelTimes('', 'Shanghai');
+      System.assert(false, 'Expected exception for missing origin');
+    } catch (AuraHandledException ex) {
+      System.assert(ex.getMessage().contains('必須'));
+    }
+  }
+}

--- a/force-app/main/default/classes/TravelTimeControllerTest.cls-meta.xml
+++ b/force-app/main/default/classes/TravelTimeControllerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomLabels xmlns="http://soap.sforce.com/2006/04/metadata">
+    <labels>
+        <fullName>Google_Maps_API_Key</fullName>
+        <categories>Integration</categories>
+        <language>ja</language>
+        <protected>false</protected>
+        <shortDescription>Google Maps API Key</shortDescription>
+        <value
+    >デプロイ後にここを実際の Google Maps API キーに置き換えてください</value>
+    </labels>
+</CustomLabels>

--- a/force-app/main/default/lwc/travelTimeEstimator/travelTimeEstimator.css
+++ b/force-app/main/default/lwc/travelTimeEstimator/travelTimeEstimator.css
@@ -1,0 +1,23 @@
+.result-card {
+  border: 1px solid var(--lwc-colorBorder, #d8dde6);
+  border-radius: 0.25rem;
+  padding: 0.75rem;
+  background-color: white;
+  box-shadow: var(--lwc-shadowCard, 0 2px 2px 0 rgba(0, 0, 0, 0.1));
+}
+
+.result-mode {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.result-duration {
+  font-size: 1.125rem;
+  color: var(--lwc-colorTextLabel, #3e3e3c);
+}
+
+.result-error {
+  color: var(--lwc-colorTextError, #c23934);
+  font-size: 0.9rem;
+}

--- a/force-app/main/default/lwc/travelTimeEstimator/travelTimeEstimator.html
+++ b/force-app/main/default/lwc/travelTimeEstimator/travelTimeEstimator.html
@@ -1,0 +1,62 @@
+<template>
+  <lightning-card title={cardTitle} icon-name="standard:travel">
+    <div class="slds-p-horizontal_medium slds-p-bottom_medium">
+      <lightning-input
+        label="出発地"
+        value={origin}
+        onchange={handleOriginChange}
+        placeholder="出発地の住所を入力してください"
+        class="slds-m-bottom_small"
+      ></lightning-input>
+      <lightning-input
+        label="到着地"
+        value={destination}
+        onchange={handleDestinationChange}
+        placeholder="到着地の住所を入力してください"
+        class="slds-m-bottom_small"
+      ></lightning-input>
+      <lightning-button
+        label="所要時間を検索"
+        variant="brand"
+        onclick={handleCalculate}
+        disabled={isLoading}
+      ></lightning-button>
+    </div>
+
+    <template if:true={isLoading}>
+      <div class="slds-is-relative slds-p-around_medium">
+        <lightning-spinner alternative-text="検索中"></lightning-spinner>
+      </div>
+    </template>
+
+    <template if:true={hasResults}>
+      <div class="slds-p-horizontal_medium slds-p-bottom_medium">
+        <lightning-layout vertical-align="stretch" multiple-rows>
+          <template for:each={results} for:item="result">
+            <lightning-layout-item
+              key={result.mode}
+              size="12"
+              class="slds-p-vertical_x-small"
+            >
+              <div class="result-card">
+                <div class="result-mode">{result.modeLabel}</div>
+                <template if:true={result.isSuccess}>
+                  <div class="result-duration">{result.durationText}</div>
+                </template>
+                <template if:false={result.isSuccess}>
+                  <div class="result-error">{result.errorMessage}</div>
+                </template>
+              </div>
+            </lightning-layout-item>
+          </template>
+        </lightning-layout>
+      </div>
+    </template>
+
+    <template if:true={error}>
+      <div class="slds-p-horizontal_medium slds-p-bottom_medium">
+        <div class="result-error">{error}</div>
+      </div>
+    </template>
+  </lightning-card>
+</template>

--- a/force-app/main/default/lwc/travelTimeEstimator/travelTimeEstimator.js
+++ b/force-app/main/default/lwc/travelTimeEstimator/travelTimeEstimator.js
@@ -1,0 +1,83 @@
+import { LightningElement, api } from "lwc";
+import getTravelTimes from "@salesforce/apex/TravelTimeController.getTravelTimes";
+
+const MODE_LABELS = {
+  driving: "車での移動",
+  walking: "徒歩",
+  transit: "公共交通機関"
+};
+
+export default class TravelTimeEstimator extends LightningElement {
+  @api cardTitle = "Google 経路時間検索";
+
+  origin = "";
+  destination = "";
+  results = [];
+  error;
+  isLoading = false;
+
+  get hasResults() {
+    return Array.isArray(this.results) && this.results.length > 0;
+  }
+
+  handleOriginChange(event) {
+    this.origin = event.target.value;
+  }
+
+  handleDestinationChange(event) {
+    this.destination = event.target.value;
+  }
+
+  async handleCalculate() {
+    this.error = undefined;
+    this.results = [];
+
+    if (!this.origin || !this.destination) {
+      this.error = "出発地と到着地を入力してください。";
+      return;
+    }
+
+    this.isLoading = true;
+
+    try {
+      const apiResults = await getTravelTimes({
+        origin: this.origin,
+        destination: this.destination
+      });
+      this.results = (apiResults || []).map((item) => ({
+        ...item,
+        modeLabel: MODE_LABELS[item.mode] || item.mode,
+        isSuccess: item.status === "OK"
+      }));
+
+      if (!this.results.length) {
+        this.error =
+          "経路情報を取得できませんでした。しばらくしてから再度お試しください。";
+      }
+    } catch (err) {
+      this.error = this.normalizeError(err);
+    } finally {
+      this.isLoading = false;
+    }
+  }
+
+  normalizeError(err) {
+    if (!err) {
+      return "不明なエラーが発生しました。";
+    }
+
+    if (Array.isArray(err.body)) {
+      return err.body.map((e) => e.message).join(", ");
+    }
+
+    if (err.body && typeof err.body.message === "string") {
+      return err.body.message;
+    }
+
+    if (typeof err.message === "string") {
+      return err.message;
+    }
+
+    return "不明なエラーが発生しました。";
+  }
+}

--- a/force-app/main/default/lwc/travelTimeEstimator/travelTimeEstimator.js-meta.xml
+++ b/force-app/main/default/lwc/travelTimeEstimator/travelTimeEstimator.js-meta.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__AppPage</target>
+        <target>lightning__RecordPage</target>
+        <target>lightning__HomePage</target>
+    </targets>
+    <targetConfigs>
+        <targetConfig
+      targets="lightning__AppPage,lightning__RecordPage,lightning__HomePage"
+    >
+            <property
+        name="cardTitle"
+        type="String"
+        default="Google 経路時間検索"
+        label="カードタイトル"
+        description="コンポーネントタイトル"
+      />
+        </targetConfig>
+    </targetConfigs>
+</LightningComponentBundle>


### PR DESCRIPTION
## Summary
- add a Travel Time Estimator LWC that lets users query Google Maps for travel durations between two addresses
- create an Apex controller that calls the Distance Matrix API for driving, walking, and transit modes using a configurable API key label
- localize the component labels, messages, and custom label content to Japanese and request results in Japanese

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69171948bc54832c94d0b924d553ae67)