### PR TITLE
Add Apex class example for invoking Prompt Flow

### DIFF
--- a/force-app/main/default/classes/PromptFlowInvokerExample.cls
+++ b/force-app/main/default/classes/PromptFlowInvokerExample.cls
@@ -1,0 +1,42 @@
+public with sharing class PromptFlowInvokerExample {
+  public class PromptFlowResponse {
+    @AuraEnabled
+    public String llmCompletion;
+
+    @AuraEnabled
+    public Map<String, Object> flowOutputs;
+  }
+
+  @AuraEnabled(cacheable=false)
+  public static PromptFlowResponse runPromptFlow(
+    String productIdentifier,
+    String extraInstruction
+  ) {
+    Map<String, Object> inputs = new Map<String, Object>{
+      'var_productIdentifier' => productIdentifier
+    };
+
+    Flow.Interview interview = Flow.Interview.createInterview(
+      'testpromptflow',
+      inputs
+    );
+
+    if (!String.isBlank(extraInstruction)) {
+      Flow.PromptMessageInput additionalInstruction = new Flow.PromptMessageInput();
+      additionalInstruction.messageType = Flow.PromptMessageType.AdditionalInstruction;
+      additionalInstruction.text = extraInstruction;
+      interview.addPromptMessage(additionalInstruction);
+    }
+
+    interview.start();
+
+    Flow.PromptResult promptResult = interview.getPromptResult();
+
+    PromptFlowResponse response = new PromptFlowResponse();
+    response.llmCompletion = promptResult != null
+      ? promptResult.completion
+      : null;
+    response.flowOutputs = interview.getVariables();
+    return response;
+  }
+}

--- a/force-app/main/default/classes/PromptFlowInvokerExample.cls-meta.xml
+++ b/force-app/main/default/classes/PromptFlowInvokerExample.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
## Summary
- add an Apex class that demonstrates how to run the testpromptflow Prompt Flow and return results
- expose the flow response via an AuraEnabled DTO that includes the LLM completion and output variables

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691817988a5c832c8ecd6aca4c7d7eeb)