### PR TITLE
Fix Prompt Flow Apex example

### DIFF
--- a/force-app/main/default/classes/PromptFlowInvokerExample.cls
+++ b/force-app/main/default/classes/PromptFlowInvokerExample.cls
@@ -1,0 +1,65 @@
+public with sharing class PromptFlowInvokerExample {
+  public class PromptFlowResponse {
+    @AuraEnabled
+    public String llmCompletion;
+
+    @AuraEnabled
+    public Map<String, Object> flowOutputs;
+  }
+
+  @AuraEnabled(cacheable=false)
+  public static PromptFlowResponse runPromptFlow(
+    String productIdentifier,
+    String extraInstruction
+  ) {
+    Map<String, Object> inputs = new Map<String, Object>{
+      'var_productIdentifier' => productIdentifier
+    };
+
+    if (!String.isBlank(extraInstruction)) {
+      inputs.put('var_additionalInstruction', extraInstruction);
+    }
+
+    Flow.Interview interview = Flow.Interview.createInterview(
+      'testpromptflow',
+      inputs
+    );
+
+    interview.start();
+
+    PromptFlowResponse response = new PromptFlowResponse();
+    response.flowOutputs = new Map<String, Object>();
+
+    List<String> outputVariableNames = new List<String>{
+      'ReturnOrderProcess_success',
+      'ReturnOrderProcess_status',
+      'ReturnOrderProcess_primaryMessage',
+      'ReturnOrderProcess_secondaryMessage',
+      'ReturnOrderProcess_returnOrderNumber',
+      'ReturnOrderProcess_caseNumber',
+      'ReturnOrderProcess_evaluation'
+    };
+
+    for (String variableName : outputVariableNames) {
+      Object value;
+      try {
+        value = interview.getVariableValue(variableName);
+      } catch (Exception ex) {
+        continue;
+      }
+
+      if (value != null) {
+        response.flowOutputs.put(variableName, value);
+      }
+    }
+
+    Object primaryMessage = response.flowOutputs.get(
+      'ReturnOrderProcess_primaryMessage'
+    );
+    response.llmCompletion = primaryMessage instanceof String
+      ? (String) primaryMessage
+      : null;
+
+    return response;
+  }
+}

--- a/force-app/main/default/classes/PromptFlowInvokerExample.cls-meta.xml
+++ b/force-app/main/default/classes/PromptFlowInvokerExample.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/flows/testpromptflow.flow-meta.xml
+++ b/force-app/main/default/flows/testpromptflow.flow-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <Flow xmlns="http://soap.sforce.com/2006/04/metadata">
     <actionCalls>
         <name>ReturnOrderProcess</name>
@@ -33,8 +33,14 @@
             <assignToReference>$Output.Prompt</assignToReference>
             <operator>Add</operator>
             <value>
-                <stringValue>これはテンプレートです
-</stringValue>
+                <stringValue>これはテンプレートです</stringValue>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>$Output.Prompt</assignToReference>
+            <operator>Add</operator>
+            <value>
+                <elementReference>var_additionalInstruction</elementReference>
             </value>
         </assignmentItems>
     </assignments>
@@ -71,6 +77,13 @@
     <status>Active</status>
     <variables>
         <name>var_productIdentifier</name>
+        <dataType>String</dataType>
+        <isCollection>false</isCollection>
+        <isInput>true</isInput>
+        <isOutput>false</isOutput>
+    </variables>
+    <variables>
+        <name>var_additionalInstruction</name>
         <dataType>String</dataType>
         <isCollection>false</isCollection>
         <isInput>true</isInput>


### PR DESCRIPTION
## Summary
- replace unsupported Prompt Flow API usage in Apex sample with Flow.Interview variable lookups and optional additional instruction inputs
- update the testpromptflow Prompt Flow to accept an extra instruction value and append it to the constructed prompt

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691817988a5c832c8ecd6aca4c7d7eeb)